### PR TITLE
organizeImports -> sortImports

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -24,7 +24,7 @@
     "editor.defaultFormatter": "denoland.vscode-deno",
     "editor.formatOnSave": true,
     "editor.codeActionsOnSave": {
-      "source.organizeImports": "explicit"
+      "source.sortImports": true
     }
   },
   "cSpell.words": [


### PR DESCRIPTION
As discussed, this changes the .vscode setting from `organizeImports` to `sortImports` to avoid disappearing imports while developing. 