### PR TITLE
Fix some typo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,7 +99,7 @@ If you want to fix a bug in Fedify, please search the [GitHub issue tracker] to
 see if the bug has already been reported.  If it hasn't been reported yet,
 please open a new issue to discuss the bug.
 
-When you open a pull request, please provide the he issue number that the pull
+When you open a pull request, please provide the issue number that the pull
 request is related to.
 
 A patch set should include the following:


### PR DESCRIPTION
This pull request fixes some typo but I'm not sure whether they are all typo or not.

- 300e836bdfd71d9c52b3445ce3298850b198915e: When I look around vocabulary definitions (yaml files), `.url` property seems valid url with anchor. But the `.url` property in `endpoints.yaml` wasn't valid because there is no `Endpoints` anchor. There was `endpoints` instead (lowercase).
- 1d6037854afc95f938c5f3967bb939be9350d129: While reading `CONTRIBUTING.md`, there was the part, `the he issue`. I felt the `he` word seems like a typo of `the`. And only one `the` word is needed, I removed it. If it is a English expression I didn't, please let me know. I'll drop the commit.