### PR TITLE
Fixed use of `setInboxDispatcher` after `setInboxListeners`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,12 @@ Version 0.11.3
 
 To be released.
 
+ -  Fixed a bug where use of `Federation.setInboxDispatcher()` after
+    `Federation.setInboxListeners()` had caused a `RouterError` to be
+    thrown even if the paths match.  [[#101] by Fabien O'Carroll]
+
+[#101]: https://github.com/dahlia/fedify/pull/101
+
 
 Version 0.11.2
 --------------

--- a/federation/middleware.test.ts
+++ b/federation/middleware.test.ts
@@ -745,6 +745,18 @@ test("Federation.setInboxDispatcher()", async (t) => {
     );
   });
 
+  await t.step("path match", () => {
+    const federation = createFederation<void>({
+      kv,
+      documentLoader: mockDocumentLoader,
+    });
+    federation.setInboxListeners("/users/{handle}/inbox");
+    federation.setInboxDispatcher(
+      "/users/{handle}/inbox",
+      () => ({ items: [] }),
+    );
+  });
+
   await t.step("wrong variables in path", () => {
     const federation = createFederation<void>({
       kv,

--- a/federation/middleware.ts
+++ b/federation/middleware.ts
@@ -1351,6 +1351,7 @@ export class Federation<TContextData> {
           "Path for inbox must have one variable: {handle}",
         );
       }
+      this.#inboxPath = inboxPath;
     }
     if (sharedInboxPath != null) {
       const siVars = this.#router.add(sharedInboxPath, "sharedInbox");


### PR DESCRIPTION
There is a bug where setting the inbox dispatcher after the listeners causes an error to be thrown due to path mismatch.