### PR TITLE
Update API reference link in vocab docs to be more specific

### DIFF
--- a/docs/manual/vocab.md
+++ b/docs/manual/vocab.md
@@ -23,7 +23,7 @@ list all of them here.  Instead, we'll show a few examples of the objects that
 are available in the library: `Create`, `Note`, and `Person`.  For the full
 list of the objects, please refer to the [API reference].
 
-[API reference]: https://jsr.io/@fedify/fedify/doc
+[API reference]: https://jsr.io/@fedify/fedify/doc/vocab/~
 
 
 Instantiation


### PR DESCRIPTION
It was a bit surprising to see every exported member after clicking that link 😅 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the API reference link to direct users more specifically to the vocabulary section, enhancing clarity for accessing vocabulary-related information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->