### PR TITLE
Missing handle mapper  in middleware.ts

### DIFF
--- a/src/federation/middleware.ts
+++ b/src/federation/middleware.ts
@@ -2063,7 +2063,7 @@ class FederationImpl<TContextData> implements Federation<TContextData> {
         return await handleWebFinger(request, {
           context,
           actorDispatcher: this.actorCallbacks?.dispatcher,
-          handleMapper: this.actorCallbacks?.handleMapper,
+          actorHandleMapper: this.actorCallbacks?.handleMapper,
           onNotFound,
         });
       case "nodeInfoJrd":

--- a/src/federation/middleware.ts
+++ b/src/federation/middleware.ts
@@ -2063,6 +2063,7 @@ class FederationImpl<TContextData> implements Federation<TContextData> {
         return await handleWebFinger(request, {
           context,
           actorDispatcher: this.actorCallbacks?.dispatcher,
+          handleMapper: this.actorCallbacks?.handleMapper,
           onNotFound,
         });
       case "nodeInfoJrd":


### PR DESCRIPTION
No actor handle mapper is set; and use the WebFinger username  as the actor's internal handle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced handling of actor mapping during the web finger process, improving flexibility in request processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->