### PR TITLE
Fix incorrect handling of relative path URIs in link alternate headers

### DIFF
--- a/src/runtime/docloader.test.ts
+++ b/src/runtime/docloader.test.ts
@@ -83,6 +83,19 @@ test("fetchDocumentLoader()", async (t) => {
       },
     ));
 
+    mf.mock("GET@/link-obj-relative", (_req) =>
+      new Response(
+        "",
+        {
+          status: 200,
+          headers: {
+            "Content-Type": "text/html; charset=utf-8",
+            Link: '</object>; rel="alternate"; ' +
+              'type="application/activity+json"',
+          },
+        },
+      ));
+
   await t.step("Link header", async () => {
     assertEquals(await fetchDocumentLoader("https://example.com/link-ctx"), {
       contextUrl: "https://www.w3.org/ns/activitystreams",
@@ -95,6 +108,29 @@ test("fetchDocumentLoader()", async (t) => {
     });
 
     assertEquals(await fetchDocumentLoader("https://example.com/link-obj"), {
+      contextUrl: null,
+      documentUrl: "https://example.com/object",
+      document: {
+        "@context": "https://www.w3.org/ns/activitystreams",
+        id: "https://example.com/object",
+        name: "Fetched object",
+        type: "Object",
+      },
+    });
+  });
+
+  await t.step("Link header relative url", async () => {
+    assertEquals(await fetchDocumentLoader("https://example.com/link-ctx"), {
+      contextUrl: "https://www.w3.org/ns/activitystreams",
+      documentUrl: "https://example.com/link-ctx",
+      document: {
+        id: "https://example.com/link-ctx",
+        name: "Fetched object",
+        type: "Object",
+      },
+    });
+
+    assertEquals(await fetchDocumentLoader("https://example.com/link-obj-relative"), {
       contextUrl: null,
       documentUrl: "https://example.com/object",
       document: {

--- a/src/runtime/docloader.ts
+++ b/src/runtime/docloader.ts
@@ -133,18 +133,19 @@ async function getRemoteDocument(
     } else {
       const entries = link.getByRel("alternate");
       for (const [uri, params] of entries) {
+        const altUri = new URL(uri, docUrl)
         if (
           "type" in params &&
           (params.type === "application/activity+json" ||
             params.type === "application/ld+json" ||
             params.type.startsWith("application/ld+json;")) &&
-          new URL(uri).href !== docUrl.href
+          altUri.href !== docUrl.href
         ) {
           logger.debug(
             "Found alternate document: {alternateUrl} from {url}",
-            { alternateUrl: uri, url: documentUrl },
+            { alternateUrl: altUri, url: documentUrl },
           );
-          return await fetch(uri);
+          return await fetch(altUri.href);
         }
       }
     }


### PR DESCRIPTION
I think I've gotten this change right, essentially the code would try to resolve `http://schema.org/` be redirected to `https://schema.org/` and get back a link alternate with: 

```
link: </docs/jsonldcontext.jsonld>; rel="alternate"; type="application/ld+json"
```

Which Fedify would correctly discover, however, it would then try to fetch `/docs/jsonldcontext.jsonld` instead of `https://schema.org/docs/jsonldcontext.jsonld`, this fetch would result in an invalid URL error.

This change should fix that by resolving alternate URIs relative to the docUrl, as is done in HTML response handling.

The test change appears to assert this but I'm not 100% sure this is correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced handling of alternate document URLs for improved resolution.
	- Added support for relative URLs in link headers within document loading.

- **Bug Fixes**
	- Expanded test coverage for document loading, specifically for relative URL handling.

- **Documentation**
	- Updated logging for clarity regarding alternate document URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->