### PR TITLE
"command prints warnings: Context-local storage is not configured" bug fixed

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,12 @@ Version 1.2.8
 
 To be released.
 
+ -  Fixed warnings from the `fedify inbox` command.
+    [[#177], [#181] by WinterHana]
+
+[#177]: https://github.com/dahlia/fedify/issues/177
+[#181]: https://github.com/dahlia/fedify/pull/181
+
 
 Version 1.2.7
 -------------

--- a/cli/log.ts
+++ b/cli/log.ts
@@ -4,6 +4,7 @@ import {
   type LogRecord,
   type Sink,
 } from "@logtape/logtape";
+import { AsyncLocalStorage } from "node:async_hooks";
 
 export interface RecordingSink extends Sink {
   startRecording(): void;
@@ -45,5 +46,6 @@ await configure({
       sinks: ["console"],
     },
   ],
+  contextLocalStorage: new AsyncLocalStorage(),
   reset: true,
 });


### PR DESCRIPTION
Closes #177 Issue complete
- Bug Fixes
In `cli > log.ts`, add line and import
```
import { AsyncLocalStorage } from "node:async_hooks";
...
contextLocalStorage: new AsyncLocalStorage(),
``` 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced logging configuration to maintain context across asynchronous operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->