### PR TITLE
fix: text overflow of inbox log view

### DIFF
--- a/cli/inbox/view.tsx
+++ b/cli/inbox/view.tsx
@@ -139,14 +139,18 @@ const Log: FC<LogProps> = (
   return (
     <li class={"list-group-item " + listClass}>
       <div class="d-flex w-100 justify-content-between">
-        <p class="mb-1" style="white-space: pre;">
+        <p class="mb-1" style="white-space: pre-wrap; word-break: break-word;">
           {message.map((m, i) =>
             i % 2 == 0
               ? m
               : <code>{typeof m === "string" ? m : Deno.inspect(m)}</code>
           )}
         </p>
-        <time class="text-body-secondary" datetime={time.toString()}>
+        <time
+          class="text-body-secondary"
+          datetime={time.toString()}
+          style="flex-shrink: 0;"
+        >
           <small>{time.toLocaleString()}</small>
         </time>
       </div>


### PR DESCRIPTION
Closes #180 

| AS-IS | TO-BE |
|-------|-------|
| <img width="1377" alt="image" src="https://github.com/user-attachments/assets/b1aea119-ff38-4687-9a62-c81adca26986"> | <img width="1314" alt="image" src="https://github.com/user-attachments/assets/3f05cca2-99e8-4ec7-8bcd-f8c9ef9cf5b7"> |

