### PR TITLE
Fix a bug where search results are broken for headings with `<a>` tag

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -42,5 +42,10 @@
     "dev": "vitepress dev",
     "build": "vitepress build",
     "preview": "vitepress preview"
+  },
+  "pnpm": {
+    "patchedDependencies": {
+      "vitepress@1.6.3": "patches/vitepress@1.6.3.patch"
+    }
   }
 }

--- a/docs/patches/vitepress@1.6.3.patch
+++ b/docs/patches/vitepress@1.6.3.patch
@@ -1,0 +1,13 @@
+diff --git a/dist/node/chunk-Zsoi3j4v.js b/dist/node/chunk-Zsoi3j4v.js
+index 8cfe39e30b9e866566716751deb57a58555b7bf8..87d80cff5751d63590810e8bdeab2fcba94c2899 100644
+--- a/dist/node/chunk-Zsoi3j4v.js
++++ b/dist/node/chunk-Zsoi3j4v.js
+@@ -40586,7 +40586,7 @@ async function localSearchPlugin(siteConfig) {
+   };
+ }
+ const headingRegex = /<h(\d*).*?>(.*?<a.*? href="#.*?".*?>.*?<\/a>)<\/h\1>/gi;
+-const headingContentRegex = /(.*?)<a.*? href="#(.*?)".*?>.*?<\/a>/i;
++const headingContentRegex = /(.*)<a.*? href="#(.*?)".*?>.*?<\/a>/i;
+ function* splitPageIntoSections(html) {
+   const result = html.split(headingRegex);
+   result.shift();

--- a/docs/pnpm-lock.yaml
+++ b/docs/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  vitepress@1.6.3:
+    hash: h3qgcktgvvyvgahwawzgugeubu
+    path: patches/vitepress@1.6.3.patch
+
 importers:
 
   .:
@@ -106,7 +111,7 @@ importers:
         version: 5.8.3
       vitepress:
         specifier: ^1.6.3
-        version: 1.6.3(@algolia/client-search@5.25.0)(@types/node@22.15.21)(postcss@8.5.3)(search-insights@2.17.3)(typescript@5.8.3)
+        version: 1.6.3(patch_hash=h3qgcktgvvyvgahwawzgugeubu)(@algolia/client-search@5.25.0)(@types/node@22.15.21)(postcss@8.5.3)(search-insights@2.17.3)(typescript@5.8.3)
       vitepress-plugin-group-icons:
         specifier: ^1.3.5
         version: 1.5.5(markdown-it@14.1.0)(vite@5.4.19(@types/node@22.15.21))
@@ -115,7 +120,7 @@ importers:
         version: 1.3.3
       vitepress-plugin-mermaid:
         specifier: ^2.0.17
-        version: 2.0.17(mermaid@11.6.0)(vitepress@1.6.3(@algolia/client-search@5.25.0)(@types/node@22.15.21)(postcss@8.5.3)(search-insights@2.17.3)(typescript@5.8.3))
+        version: 2.0.17(mermaid@11.6.0)(vitepress@1.6.3(patch_hash=h3qgcktgvvyvgahwawzgugeubu)(@algolia/client-search@5.25.0)(@types/node@22.15.21)(postcss@8.5.3)(search-insights@2.17.3)(typescript@5.8.3))
       x-forwarded-fetch:
         specifier: ^0.2.0
         version: 0.2.0
@@ -5665,14 +5670,14 @@ snapshots:
       - '@75lb/nature'
       - supports-color
 
-  vitepress-plugin-mermaid@2.0.17(mermaid@11.6.0)(vitepress@1.6.3(@algolia/client-search@5.25.0)(@types/node@22.15.21)(postcss@8.5.3)(search-insights@2.17.3)(typescript@5.8.3)):
+  vitepress-plugin-mermaid@2.0.17(mermaid@11.6.0)(vitepress@1.6.3(patch_hash=h3qgcktgvvyvgahwawzgugeubu)(@algolia/client-search@5.25.0)(@types/node@22.15.21)(postcss@8.5.3)(search-insights@2.17.3)(typescript@5.8.3)):
     dependencies:
       mermaid: 11.6.0
-      vitepress: 1.6.3(@algolia/client-search@5.25.0)(@types/node@22.15.21)(postcss@8.5.3)(search-insights@2.17.3)(typescript@5.8.3)
+      vitepress: 1.6.3(patch_hash=h3qgcktgvvyvgahwawzgugeubu)(@algolia/client-search@5.25.0)(@types/node@22.15.21)(postcss@8.5.3)(search-insights@2.17.3)(typescript@5.8.3)
     optionalDependencies:
       '@mermaid-js/mermaid-mindmap': 9.3.0
 
-  vitepress@1.6.3(@algolia/client-search@5.25.0)(@types/node@22.15.21)(postcss@8.5.3)(search-insights@2.17.3)(typescript@5.8.3):
+  vitepress@1.6.3(patch_hash=h3qgcktgvvyvgahwawzgugeubu)(@algolia/client-search@5.25.0)(@types/node@22.15.21)(postcss@8.5.3)(search-insights@2.17.3)(typescript@5.8.3):
     dependencies:
       '@docsearch/css': 3.8.2
       '@docsearch/js': 3.8.2(@algolia/client-search@5.25.0)(search-insights@2.17.3)


### PR DESCRIPTION
This pull request fixes #254 by patching VitePress package (https://github.com/vuejs/vitepress/pull/4809).