### PR TITLE
Create GitHub Actions workflow remove-npm-pr-tags.yaml

### DIFF
--- a/.github/workflows/remove-npm-pr-tags.yaml
+++ b/.github/workflows/remove-npm-pr-tags.yaml
@@ -13,8 +13,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - uses: pnpm/action-setup@v4
-        name: Install pnpm
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
         with:
           version: 10
 


### PR DESCRIPTION
## Summary

Automatically clean up temporary npm dist-tags (e.g., pr-123) when a pull request is closed.


## Related Issue

- closes #296 

## Changes

- Added a new GitHub Actions workflow: `remove-pr-npm-tags.yaml`
  - Triggers on `pull_request` events of type `closed`
    - When automatically closed by pull request merge.
  - Gracefully removes npm pr tags
    - Uses `npm dist-tag ls` to check if the tag exists
    - If it exists, removes it with `npm dist-tag rm`
  - Targets multiple packages in the monorepo
    - `@fedify/fedify`
    - `@fedify/amqp`
    - `@fedify/express`
    - `@fedify/h3`
    - `@fedify/postgres`
    - `@fedify/redis`

## Benefits

- Keeps npm package tags clean and organized
- Improves visibility of important tags (latest, dev, etc.)
- Better developer experience when browsing available package versions
- Preserves the actual package versions while removing temporary tags

## Checklist

- [ ] Did you add a changelog entry to the *CHANGES.md*?
- [ ] Did you write some relevant docs about this change (if it's a new feature)?
- [ ] Did you write a regression test to reproduce the bug (if it's a bug fix)?
- [ ] Did you write some tests for this change (if it's a new feature)?
- [x] Did you run `deno task test-all` on your machine?
