### PR TITLE
(ci) Exclude examples folder from build in docs/package.json scripts

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -47,8 +47,8 @@
     "x-forwarded-fetch": "^0.2.0"
   },
   "scripts": {
-    "dev": "cd ../ && pnpm run --filter '!{docs}' -r build && cd docs/ && vitepress dev --host",
-    "build": "cd ../ && pnpm run --filter '!{docs}' -r build && cd docs/ && vitepress build",
-    "preview": "cd ../ && pnpm run --filter '!{docs}' -r build && cd docs/ && vitepress preview"
+    "dev": "cd ../ && pnpm run --filter '!{docs}' --filter='!./examples/**' -r build && cd docs/ && vitepress dev --host",
+    "build": "cd ../ && pnpm run --filter '!{docs}' --filter '!./examples/**' -r build && cd docs/ && vitepress build",
+    "preview": "cd ../ && pnpm run --filter '!{docs}' --filter '!./examples/**' -r build && cd docs/ && vitepress preview"
   }
 }


### PR DESCRIPTION
# Summary

Fixed build error that was caused by #333 

Since, `publish-docs` step runs `cd ../ && pnpm run --filter '!{docs}' -r build && cd docs/ && vitepress build` command,
Adding examples to pnpm workspace resulted in running `pnpm run build` even though it is not necessary
