### PR TITLE
Fixed kvCache for DocLoaders reading from kv store

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,10 @@ Version 1.7.8
 
 To be released.
 
+ -  Updated `kvCache` wrapper to read from preloaded contexts rather than
+    from the KvStore. This saves network and disk overheads when parsing
+    activities and objects using the JSON-LD library.
+
 
 Version 1.7.7
 -------------

--- a/fedify/runtime/docloader.ts
+++ b/fedify/runtime/docloader.ts
@@ -456,6 +456,14 @@ export function kvCache(
   }
 
   return async (url: string): Promise<RemoteDocument> => {
+    if (url in preloadedContexts) {
+      logger.debug("Using preloaded context: {url}.", { url });
+      return {
+        contextUrl: null,
+        document: preloadedContexts[url],
+        documentUrl: url,
+      };
+    }
     const match = matchRule(url);
     if (match == null) return await loader(url);
     const key: KvKey = [...keyPrefix, url];


### PR DESCRIPTION
Fedify has several context documents built in and stored in-memory. By default the DocumentLoader will read from memory, but when it is wrapped with the kvCache, we end up reading from the kv store rather than memory which generates a lot of overhead for stores backed by an external db like Redis or MySQL.

## Summary

Improve performance when reading common contexts from the document loader

## Changes

- Updated kvCache wrapper to read from preloaded contexts

## Benefits

- This reduces network and disk overheads when parsing activitites and objects

## Checklist

- [x] Did you add a changelog entry to the *CHANGES.md*?
- [ ] ~Did you write some relevant docs about this change (if it's a new feature)?~
- [ ] ~Did you write a regression test to reproduce the bug (if it's a bug fix)?~
- [x] Did you write some tests for this change (if it's a new feature)?
- [x] Did you run `deno task test-all` on your machine?

## Additional Notes

Include any other information, context, or considerations.
