### PR TITLE
Export context testing functions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,13 @@ Version 1.8.6
 To be released.
 
 
+### @fedify/testing
+
+ -  Updated exports to include context creation functions.
+    [[#382] by muffinista]
+
+[#382]: https://github.com/fedify-dev/fedify/pull/382
+
 Version 1.8.5
 -------------
 

--- a/packages/testing/src/mod.ts
+++ b/packages/testing/src/mod.ts
@@ -9,4 +9,9 @@
  */
 
 export { MockContext, MockFederation } from "./mock.ts";
+export {
+  createContext,
+  createInboxContext,
+  createRequestContext,
+} from "./context.ts";
 export type { SentActivity } from "./mock.ts";


### PR DESCRIPTION
## Summary

It looks like the `createContext` functions are supposed to be publicly available according to the docs, but they're not being exported. This PR takes care of that.

## Related Issue

None

## Changes

Just one commit to `export` those functions.


## Checklist

- [X] Did you add a changelog entry to the *CHANGES.md*?
- [ ] Did you write some relevant docs about this change (if it's a new feature)?
- [ ] Did you write a regression test to reproduce the bug (if it's a bug fix)?
- [ ] Did you write some tests for this change (if it's a new feature)?
- [X] Did you run `deno task test-all` on your machine?

## Additional Notes

Include any other information, context, or considerations.
