### PR TITLE
fix: remove duplicate actorDispatcher null check

### DIFF
--- a/packages/fedify/src/webfinger/handler.ts
+++ b/packages/fedify/src/webfinger/handler.ts
@@ -114,7 +114,10 @@ async function handleWebFingerInternal<TContextData>(
     span,
   }: WebFingerHandlerParameters<TContextData>,
 ): Promise<Response> {
-  if (actorDispatcher == null) return await onNotFound(request);
+  if (actorDispatcher == null) {
+    logger.error("Actor dispatcher is not set.");
+    return await onNotFound(request);
+  }
   const resource = context.url.searchParams.get("resource");
   if (resource == null) {
     return new Response("Missing resource parameter.", { status: 400 });
@@ -133,10 +136,6 @@ async function handleWebFingerInternal<TContextData>(
     "webfinger.resource.scheme",
     resourceUrl.protocol.replace(/:$/, ""),
   );
-  if (actorDispatcher == null) {
-    logger.error("Actor dispatcher is not set.");
-    return await onNotFound(request);
-  }
 
   async function mapUsernameToIdentifier(
     username: string,


### PR DESCRIPTION
## Summary

Removed duplicate actorDispatcher null check in WebFinger handler.

## Related Issue

- fixes https://github.com/fedify-dev/fedify/issues/380

## Changes

Removed duplicate actorDispatcher null check in WebFinger handler.

## Benefits

Removes duplicate code to improve maintainability

## Checklist

- [ ] Did you add a changelog entry to the *CHANGES.md*?
- [ ] Did you write some relevant docs about this change (if it's a new feature)?
- [ ] Did you write a regression test to reproduce the bug (if it's a bug fix)?
- [ ] Did you write some tests for this change (if it's a new feature)?
- [x] Did you run `deno task test-all` on your machine?

## Additional Notes
