### PR TITLE
tutorial: Changed getObject to lookupObject

### DIFF
--- a/docs/tutorial/microblog.md
+++ b/docs/tutorial/microblog.md
@@ -3307,7 +3307,7 @@ app.post("/users/:username/posts", async (c) => {
       ccs: note?.ccIds,
     }),
   );
-  return c.redirect(ctx.getObjectUri(Note, noteArgs).href);
+  return c.redirect(post.url);
 });
 ~~~~
 


### PR DESCRIPTION
## Summary

The change is just a modification of the tutorial. It included a "getObject" function on the context, which does not exist. I adapted it accordingly.
