### PR TITLE
Fix fedify init to include @fedify/vocab dependency

### DIFF
--- a/packages/cli/src/init/action/deps.ts
+++ b/packages/cli/src/init/action/deps.ts
@@ -33,7 +33,8 @@ export const getDependencies = (
   pipe(
     {
       "@fedify/fedify": PACKAGE_VERSION,
-      "@logtape/logtape": "^1.1.0",
+      "@fedify/vocab": PACKAGE_VERSION,
+      "@logtape/logtape": "^1.3.5",
     },
     merge(initializer.dependencies),
     merge(kv.dependencies),

--- a/packages/cli/src/init/templates/defaults/federation.ts.tpl
+++ b/packages/cli/src/init/templates/defaults/federation.ts.tpl
@@ -1,4 +1,5 @@
-import { createFederation, Person } from "@fedify/fedify";
+import { createFederation } from "@fedify/fedify";
+import { Person } from "@fedify/vocab";
 import { getLogger } from "@logtape/logtape";
 /* imports */
 


### PR DESCRIPTION
Summary
-------

After PR #517 extracted vocabulary classes into the separate `@fedify/vocab` package, `fedify init` was still generating projects that only installed `@fedify/fedify` and imported vocabulary types from the wrong package. This PR fixes the CLI to properly configure new projects with the correct dependencies and imports.


Related issues
--------------

 -  Related to https://github.com/fedify-dev/fedify/issues/437
 -  Related to https://github.com/fedify-dev/fedify/pull/517


Changes
-------

 -  Added `@fedify/vocab` to the default dependencies in `getDependencies()`
 -  Updated the federation.ts template to import `Person` from `@fedify/vocab` instead of `@fedify/fedify`
 -  Bumped `@logtape/logtape` version from `^1.1.0` to `^1.3.5` to match the version specified in the root deno.json


Benefits
--------

Projects created with `fedify init` will now:

 -  Automatically include the `@fedify/vocab` package as a dependency
 -  Use the correct import paths for vocabulary types, preventing runtime errors
 -  Use the latest version of LogTape consistent with the monorepo


Checklist
---------

 -  [ ] ~~Did you add a changelog entry to the *CHANGES.md*?~~
 -  [ ] ~~Did you write some relevant docs about this change (if it's a new feature)?~~
 -  [ ] ~~Did you write a regression test to reproduce the bug (if it's a bug fix)?~~
 -  [ ] ~~Did you write some tests for this change (if it's a new feature)?~~
 -  [x] Did you run `mise test` on your machine?


Additional notes
----------------

This is a bug fix for the CLI package that should be included in the next release to ensure that new projects created after the vocabulary extraction work correctly out of the box.