### PR TITLE
Fix a bug where `fedify inbox` had always responded with empty payloads with tunneling

### DIFF
--- a/packages/cli/src/tempserver.ts
+++ b/packages/cli/src/tempserver.ts
@@ -42,6 +42,8 @@ export async function spawnTemporaryServer(
   }
 
   const server = serve({
+    // Note that `protocol: "https"` does not work on Deno, so we need to
+    // manually rewrite the request URL to use https: on Deno:
     fetch: "Deno" in globalThis
       ? (request) => {
         const url = new URL(request.url);


### PR DESCRIPTION
The `fedify inbox` had always responded with empty payloads with tunneling. It was due to the `fetch()` function which was hard-coded to return `new Response()` in any condition.