### PR TITLE
Fix kvCache JSDoc to reference KvStore instead of Deno.Kv

### DIFF
--- a/packages/fedify/src/utils/kv-cache.ts
+++ b/packages/fedify/src/utils/kv-cache.ts
@@ -83,7 +83,7 @@ export interface KvCacheParameters {
 }
 
 /**
- * Decorates a {@link DocumentLoader} with a cache backed by a {@link Deno.Kv}.
+ * Decorates a {@link DocumentLoader} with a cache backed by a {@link KvStore}.
  * @param parameters The parameters for the cache.
  * @returns The decorated document loader which is cache-enabled.
  */


### PR DESCRIPTION
Summary
-------

This pull request is very trivial. It just fix jsdoc of `kvCache` function to refer `KvStore` because it doesn't depend on only `Deno.Kv`


Related issue
-------------

There is no related issue when searching with `kvCache` query.


Changes
-------

 -  Fix `kvCache` JSDoc to reference KvStore instead of `Deno.Kv`


Benefits
--------

This pull request will prevent users who discovering `kvCache` function confusing from its documentation.

Checklist
---------

 -  [ ] Did you add a changelog entry to the *CHANGES.md*?
   - This pull request just fixes a typo. It may not need to record in CHANGES.md
 -  [ ] Did you write some relevant docs about this change (if it's a new feature)?
   - No. This pull request just fixes a typo.
 -  [ ] Did you write a regression test to reproduce the bug (if it's a bug fix)?
   - No. This pull request just fixes a typo.
 -  [ ] Did you write some tests for this change (if it's a new feature)?
   - No. This pull request just fixes a typo.
 -  [x] Did you run `mise test` on your machine?


Additional notes
----------------

Include any other information, context, or considerations.

- The `kvCache` function is introduced in `Initial commit` and it had depened on `Deno.Kv`
  https://github.com/fedify-dev/fedify/commit/9858cea9db609e7aa7a65b3bcec8dd0d8838b574#diff-52947ed38226794209a9e262085350f8113a77debac279bc4a1b40d849a961d0R73