### PR TITLE
Format generated vocab file before rename to avoid race condition

### DIFF
--- a/packages/vocab/deno.json
+++ b/packages/vocab/deno.json
@@ -25,7 +25,7 @@
   ],
   "tasks": {
     "check": "deno fmt --check && deno lint && deno check src/*.ts",
-    "compile": "deno run --allow-read --allow-write --allow-env --check scripts/codegen.ts && deno fmt src/vocab.ts && deno cache src/vocab.ts && deno check src/vocab.ts",
+    "compile": "deno run --allow-read --allow-write --allow-env --allow-run --check scripts/codegen.ts && deno cache src/vocab.ts && deno check src/vocab.ts",
     "test": "deno test --allow-read --allow-write --allow-env --unstable-kv --trace-leaks --parallel"
   }
 }

--- a/packages/vocab/scripts/codegen.ts
+++ b/packages/vocab/scripts/codegen.ts
@@ -2,6 +2,18 @@ import { generateVocab } from "@fedify/vocab-tools";
 import { rename } from "node:fs/promises";
 import { dirname, join } from "node:path";
 
+async function formatFile(filePath: string): Promise<void> {
+  const command = new Deno.Command("deno", {
+    args: ["fmt", filePath],
+    stderr: "piped",
+  });
+  const { code, stderr } = await command.output();
+  if (code !== 0) {
+    const errorOutput = new TextDecoder().decode(stderr);
+    throw new Error(`deno fmt failed with exit code ${code}: ${errorOutput}`);
+  }
+}
+
 async function codegen() {
   const scriptsDir = import.meta.dirname;
   if (!scriptsDir) {
@@ -12,6 +24,7 @@ async function codegen() {
   const realPath = join(schemaDir, "vocab.ts");
 
   await generateVocab(schemaDir, generatedPath);
+  await formatFile(generatedPath);
   await rename(generatedPath, realPath);
 }
 


### PR DESCRIPTION
Summary
-------

```
packages/testing test:bun: ../vocab build:self: error: The module's source code could not be parsed: Expected ',', got '<eof>' at file:///home/runner/work/fedify/fedify/packages/vocab/src/vocab.ts:62464:38
packages/testing test:bun: ../vocab build:self:             "The followedMessage must b
```

According to [logs that I see][logs-gist], it failed to run `tsdown` or `cargo check` by malformed `vocab.ts`. And it occurs when 2 or more tasks run the `build:self` script of `@fedify/vocab` package. It looks like race condition. And there is only one write behavior to `vocab.ts` directly. It is `deno fmt`.

So this pull request makes `packages/vocab/scripts/codegen.ts` script generate `vocab.ts` atomically. The *atomic* means there will be no write behavior on `vocab.ts` directly. It'll format `vocab-{uuid}.ts` with `deno fmt ...` and rename it to `vocab.ts`.

[logs-gist]: https://gist.github.com/moreal/c149f65675bc1aaf62ec059786ac24a2


Related issue
-------------

I couldn't find related issue when searching with:

- label:component/ci
- "race"
- "codegen"


Changes
-------

 -  Let `packages/vocab/scripts/codegen.ts` script generate `src/vocab.ts` which already formatted by `deno fmt <generatedPath>`
 - Let `deno task compile` in `@fedify/vocab` do not `deno fmt`. (moved to `scripts/codegen.ts` script)


Benefits
--------

I believe this change will make CI more consistently from failing by codegen-related race condition.


Checklist
---------

 -  [ ] Did you add a changelog entry to the *CHANGES.md*?
     - It doesn't change or implement public features.
 -  [ ] Did you write some relevant docs about this change (if it's a new feature)?
     - It doesn't change or implement public features.
 -  [ ] Did you write a regression test to reproduce the bug (if it's a bug fix)?
     - I'm pushed this commit to https://github.com/fedify-dev/fedify/pull/541 too, so I think whether its CI pass or not can be treated as naive test.
 -  [ ] Did you write some tests for this change (if it's a new feature)?
     - It doesn't change or implement public features.
 -  [x] Did you run `mise test` on your machine?


Additional notes
----------------


In the long term, it would be good to introduce a monorepo tool, but for now, it will be useful for CI stability.
