### PR TITLE
Exclude non-essential files from JSR publishing

### DIFF
--- a/packages/amqp/deno.json
+++ b/packages/amqp/deno.json
@@ -17,7 +17,7 @@
     "pnpm-lock.yaml"
   ],
   "publish": {
-    "exclude": ["**/*.test.ts"]
+    "exclude": ["**/*.test.ts", "tsdown.config.ts"]
   },
   "tasks": {
     "build": "pnpm build",

--- a/packages/cfworkers/deno.json
+++ b/packages/cfworkers/deno.json
@@ -14,7 +14,12 @@
     "test"
   ],
   "publish": {
-    "exclude": ["**/*.test.ts"]
+    "exclude": [
+      "**/*.test.ts",
+      "tsdown.config.ts",
+      "vitest.config.ts",
+      "wrangler.jsonc"
+    ]
   },
   "tasks": {
     "check": "deno fmt --check && deno lint && deno check src/*.ts"

--- a/packages/cli/deno.json
+++ b/packages/cli/deno.json
@@ -30,7 +30,7 @@
     "fedify-cli-*.zip"
   ],
   "publish": {
-    "exclude": ["**/*.test.ts"]
+    "exclude": ["**/*.test.ts", "tsdown.config.ts", "scripts/"]
   },
   "tasks": {
     "codegen": "deno task -f @fedify/vocab compile",

--- a/packages/elysia/deno.json
+++ b/packages/elysia/deno.json
@@ -10,7 +10,7 @@
     "node_modules"
   ],
   "publish": {
-    "exclude": ["**/*.test.ts"]
+    "exclude": ["**/*.test.ts", "tsdown.config.ts"]
   },
   "tasks": {
     "check": "deno fmt --check && deno lint && deno check src/*.ts"

--- a/packages/express/deno.json
+++ b/packages/express/deno.json
@@ -13,7 +13,7 @@
     "node_modules"
   ],
   "publish": {
-    "exclude": ["**/*.test.ts"]
+    "exclude": ["**/*.test.ts", "tsdown.config.ts"]
   },
   "tasks": {
     "check": "deno fmt --check && deno lint && deno check *.ts"

--- a/packages/fastify/deno.json
+++ b/packages/fastify/deno.json
@@ -14,7 +14,7 @@
     "node_modules"
   ],
   "publish": {
-    "exclude": ["**/*.test.ts"]
+    "exclude": ["**/*.test.ts", "tsdown.config.ts"]
   },
   "tasks": {
     "check": "deno fmt --check && deno lint && deno check src/*.ts",

--- a/packages/fedify/deno.json
+++ b/packages/fedify/deno.json
@@ -47,7 +47,10 @@
   "publish": {
     "exclude": [
       "**/*.test.ts",
-      "src/testing/"
+      "src/testing/",
+      "tsdown.config.ts",
+      "scripts/",
+      "wrangler.toml"
     ]
   },
   "tasks": {

--- a/packages/h3/deno.json
+++ b/packages/h3/deno.json
@@ -10,7 +10,7 @@
     "node_modules"
   ],
   "publish": {
-    "exclude": ["**/*.test.ts"]
+    "exclude": ["**/*.test.ts", "tsdown.config.ts"]
   },
   "tasks": {
     "check": "deno fmt --check && deno lint && deno check src/*.ts"

--- a/packages/hono/deno.json
+++ b/packages/hono/deno.json
@@ -13,7 +13,7 @@
     "node_modules"
   ],
   "publish": {
-    "exclude": ["**/*.test.ts"]
+    "exclude": ["**/*.test.ts", "tsdown.config.ts"]
   },
   "tasks": {
     "check": "deno fmt --check && deno lint && deno check src/*.ts",

--- a/packages/koa/deno.json
+++ b/packages/koa/deno.json
@@ -13,7 +13,7 @@
     "node_modules"
   ],
   "publish": {
-    "exclude": ["**/*.test.ts"]
+    "exclude": ["**/*.test.ts", "tsdown.config.ts"]
   },
   "tasks": {
     "check": "deno fmt --check && deno lint && deno check src/*.ts"

--- a/packages/lint/deno.json
+++ b/packages/lint/deno.json
@@ -10,7 +10,7 @@
     "estree": "npm:@types/estree@^1.0.8"
   },
   "publish": {
-    "exclude": ["**/*.test.ts"]
+    "exclude": ["**/*.test.ts", "tsdown.config.ts"]
   },
   "tasks": {
     "test": "deno test --allow-env"

--- a/packages/postgres/deno.json
+++ b/packages/postgres/deno.json
@@ -13,7 +13,8 @@
   ],
   "publish": {
     "exclude": [
-      "**/*.test.ts"
+      "**/*.test.ts",
+      "tsdown.config.ts"
     ]
   },
   "tasks": {

--- a/packages/redis/deno.json
+++ b/packages/redis/deno.json
@@ -14,7 +14,8 @@
   ],
   "publish": {
     "exclude": [
-      "**/*.test.ts"
+      "**/*.test.ts",
+      "tsdown.config.ts"
     ]
   },
   "tasks": {

--- a/packages/relay/deno.json
+++ b/packages/relay/deno.json
@@ -13,7 +13,7 @@
     "node_modules/"
   ],
   "publish": {
-    "exclude": ["**/*.test.ts"]
+    "exclude": ["**/*.test.ts", "tsdown.config.ts"]
   },
   "tasks": {
     "codegen": "deno task -f @fedify/vocab compile",

--- a/packages/sqlite/deno.json
+++ b/packages/sqlite/deno.json
@@ -18,7 +18,8 @@
   "publish": {
     "exclude": [
       "**/*.test.ts",
-      "!dist/"
+      "!dist/",
+      "tsdown.config.ts"
     ]
   },
   "tasks": {

--- a/packages/sveltekit/deno.json
+++ b/packages/sveltekit/deno.json
@@ -14,7 +14,7 @@
     "node_modules"
   ],
   "publish": {
-    "exclude": ["**/*.test.ts"]
+    "exclude": ["**/*.test.ts", "tsdown.config.ts"]
   },
   "tasks": {
     "check": "deno fmt --check && deno lint && deno check src/*.ts",

--- a/packages/testing/deno.json
+++ b/packages/testing/deno.json
@@ -13,7 +13,8 @@
   ],
   "publish": {
     "exclude": [
-      "**/*.test.ts"
+      "**/*.test.ts",
+      "tsdown.config.ts"
     ]
   },
   "tasks": {

--- a/packages/vocab-runtime/deno.json
+++ b/packages/vocab-runtime/deno.json
@@ -24,7 +24,7 @@
     "node_modules"
   ],
   "publish": {
-    "exclude": ["**/*.test.ts"]
+    "exclude": ["**/*.test.ts", "tsdown.config.ts"]
   },
   "tasks": {
     "check": "deno fmt --check && deno lint && deno check src/*.ts",

--- a/packages/vocab-tools/deno.json
+++ b/packages/vocab-tools/deno.json
@@ -20,7 +20,7 @@
     "src/schema.yaml"
   ],
   "publish": {
-    "exclude": ["**/*.test.ts"]
+    "exclude": ["**/*.test.ts", "tsdown.config.ts"]
   },
   "tasks": {
     "check": "deno fmt --check && deno lint && deno check src/*.ts",

--- a/packages/vocab/deno.json
+++ b/packages/vocab/deno.json
@@ -23,6 +23,9 @@
     "src/*.yaml",
     "!src/vocab.ts"
   ],
+  "publish": {
+    "exclude": ["**/*.test.ts", "tsdown.config.ts", "scripts/"]
+  },
   "tasks": {
     "check": "deno fmt --check && deno lint && deno check src/*.ts",
     "compile": "deno run --allow-read --allow-write --allow-env --allow-run scripts/codegen.ts",

--- a/packages/webfinger/deno.json
+++ b/packages/webfinger/deno.json
@@ -19,6 +19,9 @@
     "dist",
     "node_modules"
   ],
+  "publish": {
+    "exclude": ["**/*.test.ts", "tsdown.config.ts"]
+  },
   "tasks": {
     "check": "deno fmt --check && deno lint && deno check src/*.ts",
     "test": "deno test"


### PR DESCRIPTION
Summary
-------

This pull request lets each package exclude non-essential files (e.g., `tsdown.config.ts`, `scripts/`, `src/testing/*`) when publishing to JSR.


https://jsr.io/@fedify/fedify/1.10.2
<img width="2560" height="1266" alt="image" src="https://github.com/user-attachments/assets/5dcb7455-1104-475b-8ff6-ea6d3ba78634" />



Related issue
-------------

I couldn't find related issues when searching with:

- `"JSR"`
- `"unnecessary"`
- `label:component/ci`


Changes
-------

 -  Let `@fedify/amqp` exclude `tsdown.config.ts` when publishing to JSR.
 -  Let `@fedify/elysia` exclude `tsdown.config.ts` when publishing to JSR.
 -  Let `@fedify/express` exclude `tsdown.config.ts` when publishing to JSR.
 -  Let `@fedify/fastify` exclude `tsdown.config.ts` when publishing to JSR.
 -  Let `@fedify/h3` exclude `tsdown.config.ts` when publishing to JSR.
 -  Let `@fedify/hono` exclude `tsdown.config.ts` when publishing to JSR.
 -  Let `@fedify/koa` exclude `tsdown.config.ts` when publishing to JSR.
 -  Let `@fedify/lint` exclude `tsdown.config.ts` when publishing to JSR.
 -  Let `@fedify/postgres` exclude `tsdown.config.ts` when publishing to JSR.
 -  Let `@fedify/redis` exclude `tsdown.config.ts` when publishing to JSR.
 -  Let `@fedify/relay` exclude `tsdown.config.ts` when publishing to JSR.
 -  Let `@fedify/sqlite` exclude `tsdown.config.ts` when publishing to JSR.
 -  Let `@fedify/sveltekit` exclude `tsdown.config.ts` when publishing to JSR.
 -  Let `@fedify/testing` exclude `tsdown.config.ts` when publishing to JSR.
 -  Let `@fedify/vocab-runtime` exclude `tsdown.config.ts` when publishing to JSR.
 -  Let `@fedify/vocab-tools` exclude `tsdown.config.ts` when publishing to JSR.
 -  Let `@fedify/cfworkers` exclude `tsdown.config.ts`, `vitest.config.ts` and `wrangler.jsonc` when publishing to JSR.
 -  Let `@fedify/cli` exclude `tsdown.config.ts` and `scripts/` when publishing to JSR.
 -  Let `@fedify/fedify` exclude `tsdown.config.ts`, `scripts/` and `wrangler.toml` when publishing to JSR.
 -  Let `@fedify/vocab` exclude `tsdown.config.ts` and `**/*.test.ts` when publishing to JSR.
 -  Let `@fedify/webfinger` exclude `tsdown.config.ts` and `**/*.test.ts` when publishing to JSR.

Benefits
--------

While the reduction in file size might not be huge, it means library users won't have to download unnecessary files.


Checklist
---------

 -  [ ] Did you add a changelog entry to the *CHANGES.md*?
 -  [ ] Did you write some relevant docs about this change (if it's a new feature)?
 -  [ ] Did you write a regression test to reproduce the bug (if it's a bug fix)?
 -  [ ] Did you write some tests for this change (if it's a new feature)?
 -  [x] Did you run `mise test` on your machine?