### PR TITLE
Add backward compatibility for @fedify/fedify/vocab module

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -90,6 +90,12 @@ To be released.
      -  Removed `@fedify/fedify/x/sveltekit` in favor of `@fedify/sveltekit`.
      -  Removed `@fedify/fedify/x/fresh` (Fresh integration). [[#466]]
 
+ -  Deprecated the `@fedify/fedify/vocab` module in favor of the new
+    `@fedify/vocab` package.  The `@fedify/fedify/vocab` module now re-exports
+    all exports from `@fedify/vocab` for backward compatibility, but will be
+    removed in a future version.  Please migrate to `@fedify/vocab` directly.
+    [[#437], [#517] by ChanHaeng Lee]
+
  -  The `KvStore.list()` method is now required instead of optional.
     This method was added as optional in version 1.10.0 to give existing
     implementations time to add support.  All official `KvStore` implementations
@@ -119,6 +125,7 @@ To be released.
 [#393]: https://github.com/fedify-dev/fedify/pulls/393
 [#433]: https://github.com/fedify-dev/fedify/pull/433
 [#434]: https://github.com/fedify-dev/fedify/pull/434
+[#437]: https://github.com/fedify-dev/fedify/issues/437
 [#441]: https://github.com/fedify-dev/fedify/issues/441
 [#444]: https://github.com/fedify-dev/fedify/issues/444
 [#445]: https://github.com/fedify-dev/fedify/pull/445
@@ -126,6 +133,7 @@ To be released.
 [#466]: https://github.com/fedify-dev/fedify/issues/466
 [#499]: https://github.com/fedify-dev/fedify/issues/499
 [#506]: https://github.com/fedify-dev/fedify/pull/506
+[#517]: https://github.com/fedify-dev/fedify/pull/517
 [#536]: https://github.com/fedify-dev/fedify/issues/536
 [#538]: https://github.com/fedify-dev/fedify/issues/538
 [#540]: https://github.com/fedify-dev/fedify/pull/540
@@ -283,17 +291,15 @@ To be released.
     including parsing and generating WebFinger documents.
     [[#517] by ChanHaeng Lee]
 
-[#517]: https://github.com/fedify-dev/fedify/pull/517
-
 ### @fedify/vocab
 
  -  Created ActivityPub Vocabulary API package as the *@fedify/vocab* package.
     This package contains the generated Activity Vocabulary classes and
     related types, separated from the main *@fedify/fedify* package to
     improve modularity and enable custom vocabulary extensions.
+    The previous `@fedify/fedify/vocab` module is now deprecated and
+    re-exports all exports from this package for backward compatibility.
     [[#437], [#517] by ChanHaeng Lee]
-
-[#437]: https://github.com/fedify-dev/fedify/issues/437
 
 ### @fedify/sqlite
 

--- a/packages/fedify/deno.json
+++ b/packages/fedify/deno.json
@@ -9,7 +9,8 @@
     "./nodeinfo": "./src/nodeinfo/mod.ts",
     "./otel": "./src/otel/mod.ts",
     "./sig": "./src/sig/mod.ts",
-    "./utils": "./src/utils/mod.ts"
+    "./utils": "./src/utils/mod.ts",
+    "./vocab": "./src/vocab/mod.ts"
   },
   "imports": {
     "@multiformats/base-x": "npm:@multiformats/base-x@^4.0.1",

--- a/packages/fedify/package.json
+++ b/packages/fedify/package.json
@@ -107,6 +107,16 @@
       "import": "./dist/utils/mod.js",
       "require": "./dist/utils/mod.cjs",
       "default": "./dist/utils/mod.js"
+    },
+    "./vocab": {
+      "types": {
+        "import": "./dist/vocab/mod.d.ts",
+        "require": "./dist/vocab/mod.d.cts",
+        "default": "./dist/vocab/mod.d.ts"
+      },
+      "import": "./dist/vocab/mod.js",
+      "require": "./dist/vocab/mod.cjs",
+      "default": "./dist/vocab/mod.js"
     }
   },
   "dependencies": {

--- a/packages/fedify/src/vocab/mod.ts
+++ b/packages/fedify/src/vocab/mod.ts
@@ -1,0 +1,13 @@
+/**
+ * A set of type-safe object mappings for the [Activity
+ * Vocabulary](https://www.w3.org/TR/activitystreams-vocabulary/).
+ *
+ * @deprecated This module has been moved to the `@fedify/vocab` package.
+ *             Please use `@fedify/vocab` instead of `@fedify/fedify/vocab`.
+ *             This module will be removed in a future version.
+ *             See {@link https://github.com/fedify-dev/fedify/issues/437}
+ *             and {@link https://github.com/fedify-dev/fedify/pull/517}
+ *             for more details.
+ * @module
+ */
+export * from "@fedify/vocab";

--- a/packages/fedify/tsdown.config.ts
+++ b/packages/fedify/tsdown.config.ts
@@ -12,6 +12,7 @@ export default [
       "./src/otel/mod.ts",
       "./src/utils/mod.ts",
       "./src/sig/mod.ts",
+      "./src/vocab/mod.ts",
     ],
     dts: true,
     format: ["esm", "cjs"],


### PR DESCRIPTION
## Summary

Restores the `@fedify/fedify/vocab` module as a deprecated re-export of `@fedify/vocab` to maintain backward compatibility after the vocabulary split in #517.

The `@fedify/vocab` package was split out from `@fedify/fedify` in #517, but the original `@fedify/fedify/vocab` module was completely removed. This broke existing code that imports from `@fedify/fedify/vocab`.

This PR adds back the module as a deprecated wrapper that re-exports everything from `@fedify/vocab`, allowing existing code to continue working while users migrate to the new package.

## Related issues

- Related to #437
- Follow-up to #517

## Changes

- Created `packages/fedify/src/vocab/mod.ts` that re-exports all exports from `@fedify/vocab` with `@deprecated` JSDoc tags
- Added `./vocab` export to `packages/fedify/deno.json` for Deno environment
- Added `./vocab` export to `packages/fedify/package.json` for Node.js/Bun environments
- Added `./src/vocab/mod.ts` to `packages/fedify/tsdown.config.ts` build entry points
- Updated `CHANGES.md` to document the deprecation in both `@fedify/fedify` and `@fedify/vocab` sections

## Benefits

- *Backward Compatibility*: Existing code using `@fedify/fedify/vocab` continues to work without breaking
- *Smooth Migration Path*: Users can gradually migrate to `@fedify/vocab` at their own pace
- *Clear Deprecation Warnings*: JSDoc `@deprecated` tags guide users toward the new package
- *Cross-Runtime Support*: Works in all environments (Deno, Node.js, Bun)

## Migration guide (for users)

Users are encouraged to migrate from:

```typescript
// Old (deprecated)
import { Note, Create } from "@fedify/fedify/vocab";
```

To:

```typescript
// New (recommended)
import { Note, Create } from "@fedify/vocab";
```

The old import path will continue to work but will show deprecation warnings in IDEs and documentation.

## Checklist

- [x] Did you add a changelog entry to the *CHANGES.md*?
- [x] Did you write some relevant docs about this change (if it's a new feature)?
- [x] Did you run `deno task test-all` on your machine?