### PR TITLE
Allow slow types during Deno publish in CI workflows

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -341,7 +341,7 @@ jobs:
         mise run codegen
         max_attempts=5
         attempt=1
-        until deno publish --allow-dirty; do
+        until deno publish --allow-dirty --allow-slow-types; do
           exit_code=$?
           if [[ $attempt -ge $max_attempts ]]; then
             echo "deno publish failed after $max_attempts attempts"

--- a/.github/workflows/publish-pr.yaml
+++ b/.github/workflows/publish-pr.yaml
@@ -157,7 +157,7 @@ jobs:
         mise run codegen
         max_attempts=5
         attempt=1
-        until deno publish --allow-dirty; do
+        until deno publish --allow-dirty --allow-slow-types; do
           exit_code=$?
           if [[ $attempt -ge $max_attempts ]]; then
             echo "deno publish failed after $max_attempts attempts"


### PR DESCRIPTION
Summary
-------

Allow slow types during Deno publish in CI workflows.

Related issue
-------------

No related issues yet but there's a [error](https://github.com/fedify-dev/fedify/actions/runs/22115821869/job/63924392516) on CI.

Changes
-------

 -  Added `--allow-slow-types` on `deno publish` commands.


Benefits
--------

There will be no `no-slow-types` error.


Checklist
---------

 -  [ ] ~~Did you add a changelog entry to the *CHANGES.md*?~~
 -  [ ] ~~Did you write some relevant docs about this change (if it's a new feature)?~~
 -  [ ] ~~Did you write a regression test to reproduce the bug (if it's a bug fix)?~~
 -  [ ] ~~Did you write some tests for this change (if it's a new feature)?~~
 -  [x] Did you run `mise test` on your machine?


Additional notes
----------------

If Deno Workspaces allows for removing `no-slow-type` on a per-package basis, this PR should be reverted and the setting should be applied only to the `@fedify/init` package.
