### PR TITLE
Add context helpers for actor keys by usage

### DIFF
--- a/packages/fedify/src/federation/context.ts
+++ b/packages/fedify/src/federation/context.ts
@@ -212,6 +212,28 @@ export interface Context<TContextData> {
   getActorKeyPairs(identifier: string): Promise<ActorKeyPair[]>;
 
   /**
+   * Gets the actor's public keys grouped by usage.
+   * @param identifier The actor's identifier.
+   * @returns The actor's public keys and assertion methods. It can be empty.
+   * @since 2.2.0
+   */
+  getActorKeysByUsage(identifier: string): Promise<{
+    publicKeys: CryptographicKey[];
+    assertionMethods: Multikey[];
+  }>;
+
+  /**
+   * Gets the first actor key per usage.
+   * @param identifier The actor's identifier.
+   * @returns The first public key and assertion method, if available.
+   * @since 2.2.0
+   */
+  getActorFirstKeyByUsage(identifier: string): Promise<{
+    publicKey: CryptographicKey | undefined;
+    assertionMethod: Multikey | undefined;
+  }>;
+
+  /**
    * Gets an authenticated {@link DocumentLoader} for the given identity.
    * Note that an authenticated document loader intentionally does not cache
    * the fetched documents.

--- a/packages/fedify/src/federation/middleware.test.ts
+++ b/packages/fedify/src/federation/middleware.test.ts
@@ -305,8 +305,9 @@ test({
         { type: "actor", identifier: "handle" },
       );
       assertEquals(ctx.parseUri(null), null);
+      const keyPairs = await ctx.getActorKeyPairs("handle");
       assertEquals(
-        await ctx.getActorKeyPairs("handle"),
+        keyPairs,
         [
           {
             keyId: new URL("https://example.com/users/handle#main-key"),
@@ -338,6 +339,14 @@ test({
           },
         ],
       );
+      assertEquals(await ctx.getActorKeysByUsage("handle"), {
+        publicKeys: keyPairs.map((key) => key.cryptographicKey),
+        assertionMethods: keyPairs.map((key) => key.multikey),
+      });
+      assertEquals(await ctx.getActorFirstKeyByUsage("handle"), {
+        publicKey: keyPairs[0].cryptographicKey,
+        assertionMethod: keyPairs[0].multikey,
+      });
       const loader = await ctx.getDocumentLoader({ identifier: "handle" });
       assertEquals(await loader("https://example.com/auth-check"), {
         contextUrl: null,

--- a/packages/fedify/src/federation/middleware.ts
+++ b/packages/fedify/src/federation/middleware.ts
@@ -1969,6 +1969,29 @@ export class ContextImpl<TContextData> implements Context<TContextData> {
     return result;
   }
 
+  async getActorKeysByUsage(identifier: string): Promise<{
+    publicKeys: CryptographicKey[];
+    assertionMethods: Multikey[];
+  }> {
+    const keys = await this.getActorKeyPairs(identifier);
+    return {
+      publicKeys: keys.map((key) => key.cryptographicKey),
+      assertionMethods: keys.map((key) => key.multikey),
+    };
+  }
+
+  async getActorFirstKeyByUsage(identifier: string): Promise<{
+    publicKey: CryptographicKey | undefined;
+    assertionMethod: Multikey | undefined;
+  }> {
+    const { publicKeys, assertionMethods } =
+      await this.getActorKeysByUsage(identifier);
+    return {
+      publicKey: publicKeys[0],
+      assertionMethod: assertionMethods[0],
+    };
+  }
+
   protected async getKeyPairsFromIdentifier(
     identifier: string,
   ): Promise<(CryptoKeyPair & { keyId: URL })[]> {


### PR DESCRIPTION
Summary
-------

Add Context helpers to retrieve actor public keys and assertion methods by usage, plus a convenience method for the first key.

Related issue
-------------

 -  fixes #488

Changes
-------

 -  extend Context interface with getActorKeysByUsage/getActorFirstKeyByUsage
 -  implement the new helpers in ContextImpl
 -  add tests covering the new helpers

Benefits
--------

Simplifies actor dispatcher code by avoiding manual key pair mapping for public keys and assertion methods.

Checklist
---------

 -  [ ] Did you add a changelog entry to the *CHANGES.md*?
 -  [ ] Did you write some relevant docs about this change (if it's a new feature)?
 -  [ ] Did you write a regression test to reproduce the bug (if it's a bug fix)?
 -  [x] Did you write some tests for this change (if it's a new feature)?
 -  [ ] Did you run `mise test` on your machine?

Additional notes
----------------

Tests not run (not requested).
