### PR TITLE
Create fresh response object in default Fastify handler

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,14 @@ Version 2.0.4
 
 To be released.
 
+### @fedify/fastify
+
+ -  Fixed the default `onNotAcceptable` handler in `@fedify/fastify` to
+    create a fresh `Response` for each request instead of reusing a shared
+    singleton instance.  [[#612] by Lee Dogeon]
+
+[#612]: https://github.com/fedify-dev/fedify/pull/612
+
 
 Version 2.0.3
 -------------

--- a/packages/fastify/src/index.test.ts
+++ b/packages/fastify/src/index.test.ts
@@ -129,6 +129,43 @@ test("Fedify should handle notAcceptable and return 406", async () => {
   await fastify.close();
 });
 
+test("Fedify should create a fresh 406 response for each request", async () => {
+  const fastify = Fastify({ logger: false });
+  const federation = createFederation<void>({ kv: new MemoryKvStore() });
+
+  federation.setActorDispatcher(
+    "/users/{identifier}",
+    (_ctx: RequestContext<void>, identifier: string) => {
+      return new Person({
+        id: new URL(`https://example.com/users/${identifier}`),
+        preferredUsername: identifier,
+        name: `User ${identifier}`,
+      });
+    },
+  );
+
+  await fastify.register(fedifyPlugin, { federation });
+  await fastify.ready();
+
+  const firstResponse = await fastify.inject({
+    method: "GET",
+    url: "/users/alice",
+    headers: { "Accept": "text/html" },
+  });
+  const secondResponse = await fastify.inject({
+    method: "GET",
+    url: "/users/alice",
+    headers: { "Accept": "text/html" },
+  });
+
+  assert.equal(firstResponse.statusCode, 406);
+  assert.equal(firstResponse.body, "Not Acceptable");
+  assert.equal(secondResponse.statusCode, 406);
+  assert.equal(secondResponse.body, "Not Acceptable");
+
+  await fastify.close();
+});
+
 test("Fedify should handle notAcceptable with custom error handler", async () => {
   const fastify = Fastify({ logger: false });
   const federation = createFederation<void>({ kv: new MemoryKvStore() });

--- a/packages/fastify/src/index.ts
+++ b/packages/fastify/src/index.ts
@@ -76,7 +76,7 @@ const fedifyPluginCore: FastifyPluginAsync<FedifyPluginOptions<unknown>> = (
 
     const response = await federation.fetch(webRequest, {
       contextData,
-      onNotAcceptable: () => defaultNotAcceptableResponse,
+      onNotAcceptable: createDefaultNotAcceptableResponse,
       onNotFound: () => dummyNotFoundResponse,
       ...errorHandlers,
     });
@@ -101,10 +101,11 @@ const fedifyPlugin: FastifyPluginAsync<FedifyPluginOptions<unknown>> = fp(
 );
 
 const dummyNotFoundResponse = new Response("", { status: 404 });
-const defaultNotAcceptableResponse = new Response("Not Acceptable", {
-  status: 406,
-  headers: { "Content-Type": "text/plain", Vary: "Accept" },
-});
+const createDefaultNotAcceptableResponse = () =>
+  new Response("Not Acceptable", {
+    status: 406,
+    headers: { "Content-Type": "text/plain", Vary: "Accept" },
+  });
 
 /**
  * Convert Fastify request to Web API Request.


### PR DESCRIPTION
Summary
-------

This pull request just let `@fedify/fastify` create a fresh `Response` object by default *not acceptable* handler.

When running the `examples/fastify` project and executing the following `curl` command twice:

```
fastify % curl http://localhost:3000/users/someone
Not Acceptable
fastify % curl http://localhost:3000/users/someone
{"statusCode":500,"code":"FST_ERR_REP_RESPONSE_BODY_CONSUMED","error":"Internal Server Error","message":"Response.body is already consumed."}
```

It returns 500 error because the response stream is already consumed. You can re-check it by running the regression test (in `index.test.ts` file)

This pull request just make it return a new `Response` object for each request.


Related issue
-------------

There is no related issue.


Changes
-------

List the specific modifications made in this PR.
Focus on *what* was changed without going into detail about impact.

 -  Let default *onNotAcceptable* handler to create a new `Response` object.
 -  Added a regression test about the above situation.


Benefits
--------

It will make server applications using `@fedify/fastify` without their `onNotAcceptable` handler return a valid 406 response (Not Acceptable).


Checklist
---------

 -  [x] Did you add a changelog entry to the *CHANGES.md*?
 -  [ ] Did you write some relevant docs about this change (if it's a new feature)?
 -  [x] Did you write a regression test to reproduce the bug (if it's a bug fix)?
 -  [ ] Did you write some tests for this change (if it's a new feature)?
 -  [x] Did you run `mise test` on your machine?