### PR TITLE
Add `http://joinmastodon.org/ns` to preloaded JSON-LD contexts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,17 @@ Version 2.0.6
 
 To be released.
 
+### @fedify/vocab-runtime
+
+ -  Added `http://joinmastodon.org/ns` to preloaded JSON-LD contexts.
+    This URL has never served a real JSON-LD context document (Mastodon
+    has always inlined the term definitions), but some ActivityPub
+    implementations put it as a bare URL in their `@context`, causing
+    JSON-LD processors to fail with a 404.  [[#630], [#631]]
+
+[#630]: https://github.com/fedify-dev/fedify/issues/630
+[#631]: https://github.com/fedify-dev/fedify/pull/631
+
 
 Version 2.0.5
 -------------

--- a/packages/vocab-runtime/src/contexts.ts
+++ b/packages/vocab-runtime/src/contexts.ts
@@ -4314,6 +4314,44 @@ const preloadedContexts: Record<string, unknown> = {
       },
     },
   },
+
+  // Mastodon's "toot:" namespace.  The URL http://joinmastodon.org/ns has
+  // *never* served a real JSON-LD context document—Mastodon has always inlined
+  // these term definitions directly in every outgoing @context array.  However,
+  // some ActivityPub implementations (e.g., Bonfire) put the bare URL in their
+  // @context, which causes JSON-LD processors to try to dereference it and fail
+  // with a 404.  We ship a built-in copy here so that Fedify can parse such
+  // documents without a network round-trip to a URL that will never resolve.
+  // See: https://github.com/mastodon/joinmastodon/issues/148
+  //      https://github.com/fedify-dev/fedify/issues/630
+  "http://joinmastodon.org/ns": {
+    "@context": {
+      "toot": "http://joinmastodon.org/ns#",
+      "Emoji": "toot:Emoji",
+      "featured": {
+        "@id": "toot:featured",
+        "@type": "@id",
+      },
+      "featuredTags": {
+        "@id": "toot:featuredTags",
+        "@type": "@id",
+      },
+      "focalPoint": {
+        "@container": "@list",
+        "@id": "toot:focalPoint",
+      },
+      "blurhash": "toot:blurhash",
+      "discoverable": "toot:discoverable",
+      "indexable": "toot:indexable",
+      "memorial": "toot:memorial",
+      "votersCount": "toot:votersCount",
+      "suspended": "toot:suspended",
+      "attributionDomains": {
+        "@id": "toot:attributionDomains",
+        "@type": "@id",
+      },
+    },
+  },
 };
 
 export default preloadedContexts;


### PR DESCRIPTION
Closes #630.

`http://joinmastodon.org/ns` is used as the base URI for Mastodon’s custom JSON-LD terms like `Emoji`, `discoverable`, `featured`, `blurhash`, etc. However, this URL has never actually hosted a JSON-LD context document. Gargron [confirmed](https://github.com/mastodon/joinmastodon/issues/148#issuecomment-1133782292) that it is a “fake” namespace, and Mastodon has always inlined the term definitions directly in every outgoing `@context` array rather than pointing to a resolvable document.

This works fine as long as everyone inlines the definitions the same way Mastodon does. The problem is that some ActivityPub implementations (notably Bonfire) put `http://joinmastodon.org/ns` as a bare URL in their `@context`, presumably expecting it to be a real, dereferenceable context. When Fedify encounters such a document, the JSON-LD processor tries to fetch that URL, gets a 404, and the entire parsing fails with `jsonld.InvalidUrl`.

Ideally, `joinmastodon.org` would host a proper context document at that URL, but given that this has been the case since 2021 and [the upstream issue](https://github.com/mastodon/joinmastodon/issues/148) was closed as “answered” without any fix, it seems unlikely to change. So this PR adds a preloaded context for `http://joinmastodon.org/ns` in *packages/vocab-runtime/src/contexts.ts*, covering all 11 `toot:` terms that Mastodon defines inline: `Emoji`, `featured`, `featuredTags`, `focalPoint`, `blurhash`, `discoverable`, `indexable`, `memorial`, `votersCount`, `suspended`, and `attributionDomains`.
