### PR TITLE
Support tombstones in actor dispatchers and request contexts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,10 +10,19 @@ To be released.
 
 ### @fedify/fedify
 
+ -  Allowed actor dispatchers to return `Tombstone` for deleted accounts.
+    Fedify now serves those actor URIs as `410 Gone` with the serialized
+    tombstone body, and the corresponding WebFinger lookups also return
+    `410 Gone` instead of pretending the account was never handled.
+    [[#644], [#680]]
+
  -  Added `DoubleKnockOptions.maxRedirection` to configure the maximum number
     of redirects followed by `doubleKnock()`.
     `getAuthenticatedDocumentLoader()` now also respects
     `GetAuthenticatedDocumentLoaderOptions.maxRedirection`.
+
+[#644]: https://github.com/fedify-dev/fedify/issues/644
+[#680]: https://github.com/fedify-dev/fedify/pull/680
 
 ### @fedify/vocab-runtime
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,9 @@ To be released.
     Fedify now serves those actor URIs as `410 Gone` with the serialized
     tombstone body, and the corresponding WebFinger lookups also return
     `410 Gone` instead of pretending the account was never handled.
+    Added a `RequestContext.getActor()` overload that can return those
+    tombstones to application code when called with
+    `{ tombstone: "passthrough" }`.
     [[#644], [#680]]
 
  -  Added `DoubleKnockOptions.maxRedirection` to configure the maximum number

--- a/docs/manual/actor.md
+++ b/docs/manual/actor.md
@@ -14,8 +14,8 @@ by its identifier.  Since the actor dispatcher is the most significant part of
 Fedify, it is the first thing you need to do to make Fedify work.
 
 An actor dispatcher is a callback function that takes a `Context` object and
-an identifier, and returns an actor object.  The actor object can be one of
-the following:
+an identifier, and returns an actor object, a `Tombstone`, or `null`.
+Live actor objects can be one of the following:
 
  -  `Application`
  -  `Group`
@@ -25,7 +25,7 @@ the following:
 
 The below example shows how to register an actor dispatcher:
 
-~~~~ typescript{7-15} twoslash
+~~~~ typescript{8-16} twoslash
 // @noErrors: 2451 2345
 import type { Federation } from "@fedify/fedify";
 const federation = null as unknown as Federation<void>;
@@ -53,6 +53,32 @@ federation.setActorDispatcher("/users/{identifier}", async (ctx, identifier) => 
 In the above example, the `~Federatable.setActorDispatcher()` method registers
 an actor dispatcher for the `/users/{identifier}` path.  This pattern syntax
 follows the [URI Template] specification.
+
+If the actor exists but should be represented as deleted, return a `Tombstone`
+instead of `null`:
+
+~~~~ typescript twoslash
+// @noErrors: 2345
+import { type Federation } from "@fedify/fedify";
+import { Tombstone } from "@fedify/vocab";
+const federation = null as unknown as Federation<void>;
+const deletedAt = Temporal.Instant.from("2024-01-15T00:00:00Z");
+// ---cut-before---
+federation.setActorDispatcher("/users/{identifier}", async (ctx, identifier) => {
+  if (identifier !== "alice") return null;
+  return new Tombstone({
+    id: ctx.getActorUri(identifier),
+    deleted: deletedAt,
+  });
+});
+~~~~
+
+When an actor dispatcher returns a `Tombstone`, Fedify responds from the actor
+endpoint with `410 Gone` and the serialized tombstone body.  WebFinger for the
+same account also responds with `410 Gone`.
+
+Use `null` only when the identifier is not handled at all and the request
+should fall through to the next middleware or `onNotFound` handler.
 
 > [!TIP]
 > By registering the actor dispatcher, `Federation.fetch()` automatically

--- a/docs/manual/context.md
+++ b/docs/manual/context.md
@@ -214,6 +214,26 @@ if (actor != null) {
 }
 ~~~~
 
+By default, `RequestContext.getActor()` suppresses tombstoned actors and returns
+`null` for them.  If you need to distinguish a deleted actor from a missing
+identifier, pass `{ tombstone: "passthrough" }`:
+
+~~~~ typescript twoslash
+import { type Federation } from "@fedify/fedify";
+import { Tombstone } from "@fedify/vocab";
+const federation = null as unknown as Federation<void>;
+const request = new Request("");
+const identifier: string = "";
+// ---cut-before---
+const ctx = federation.createContext(request, undefined);
+const actor = await ctx.getActor(identifier, {
+  tombstone: "passthrough",
+});
+if (actor instanceof Tombstone) {
+  console.log(`${identifier} was deleted at ${actor.deleted}`);
+}
+~~~~
+
 > [!NOTE]
 > The `RequestContext.getActor()` method is only available when the actor
 > dispatcher is registered to the `Federation` object.  If the actor dispatcher

--- a/docs/manual/webfinger.md
+++ b/docs/manual/webfinger.md
@@ -202,8 +202,6 @@ The WebFinger links dispatcher receives two parameters:
 > Fedify responds to the corresponding WebFinger lookup with `410 Gone`
 > instead of a JRD document.  This matches the actor endpoint behavior,
 > which also returns `410 Gone` for the tombstoned actor URI.
-
-> [!NOTE]
 > Before the introduction of `~Federatable.setWebFingerLinksDispatcher()` in
 > Fedify 1.9.0, WebFinger responses could only be customized through
 > `~Federatable.setActorDispatcher()` by setting the actor's `url` property.

--- a/docs/manual/webfinger.md
+++ b/docs/manual/webfinger.md
@@ -198,6 +198,12 @@ The WebFinger links dispatcher receives two parameters:
 > route.
 
 > [!NOTE]
+> If your actor dispatcher returns a `Tombstone` for a deleted account,
+> Fedify responds to the corresponding WebFinger lookup with `410 Gone`
+> instead of a JRD document.  This matches the actor endpoint behavior,
+> which also returns `410 Gone` for the tombstoned actor URI.
+
+> [!NOTE]
 > Before the introduction of `~Federatable.setWebFingerLinksDispatcher()` in
 > Fedify 1.9.0, WebFinger responses could only be customized through
 > `~Federatable.setActorDispatcher()` by setting the actor's `url` property.

--- a/docs/tutorial/basics.md
+++ b/docs/tutorial/basics.md
@@ -471,8 +471,9 @@ In the above code, we use the `~Federatable.setActorDispatcher()` method to set
 an actor dispatcher for the server.  The first argument is the path pattern
 for the actor, and the second argument is a callback function that takes
 a `Context` object and the actor's identifier.  The callback function should
-return an `Actor` object or `null` if the actor is not found.  In this case,
-we return a `Person` object for the actor *me*.
+return an `Actor` object, a `Tombstone` if the account is gone, or `null` if
+the actor is not found.  In this case, we return a `Person` object for the
+actor *me*.
 
 Alright, we have an actor on the server.  Let's see if it works by querying
 WebFinger for the actor.  Run the server by executing the following command:

--- a/packages/fedify/src/federation/builder.ts
+++ b/packages/fedify/src/federation/builder.ts
@@ -6,7 +6,7 @@ import type {
   Object,
   Recipient,
 } from "@fedify/vocab";
-import { getTypeId } from "@fedify/vocab";
+import { getTypeId, Tombstone } from "@fedify/vocab";
 import { getLogger } from "@logtape/logtape";
 import { SpanKind, SpanStatusCode, trace } from "@opentelemetry/api";
 import type { Tracer } from "@opentelemetry/api";
@@ -265,6 +265,7 @@ export class FederationBuilderImpl<TContextData>
               "Context.getActorUri(identifier).",
           );
         }
+        if (actor instanceof Tombstone) return actor;
         if (
           this.followingCallbacks != null &&
           this.followingCallbacks.dispatcher != null

--- a/packages/fedify/src/federation/callback.ts
+++ b/packages/fedify/src/federation/callback.ts
@@ -1,4 +1,4 @@
-import type { Activity, Actor, Object } from "@fedify/vocab";
+import type { Activity, Actor, Object, Tombstone } from "@fedify/vocab";
 import type { Link } from "@fedify/webfinger";
 import type { VerifyRequestFailureReason } from "../sig/http.ts";
 import type { NodeInfo } from "../nodeinfo/types.ts";
@@ -28,7 +28,7 @@ export type WebFingerLinksDispatcher<TContextData> = (
 ) => readonly Link[] | Promise<readonly Link[]>;
 
 /**
- * A callback that dispatches an {@link Actor} object.
+ * A callback that dispatches an {@link Actor} object or a {@link Tombstone}.
  *
  * @template TContextData The context data to pass to the {@link Context}.
  * @param context The request context.
@@ -37,7 +37,7 @@ export type WebFingerLinksDispatcher<TContextData> = (
 export type ActorDispatcher<TContextData> = (
   context: RequestContext<TContextData>,
   identifier: string,
-) => Actor | null | Promise<Actor | null>;
+) => Actor | Tombstone | null | Promise<Actor | Tombstone | null>;
 
 /**
  * A callback that dispatches key pairs for an actor.

--- a/packages/fedify/src/federation/context.ts
+++ b/packages/fedify/src/federation/context.ts
@@ -514,8 +514,24 @@ export interface RequestContext<TContextData> extends Context<TContextData> {
    */
   getActor(
     identifier: string,
-    options?: GetActorOptions,
+    options: GetActorOptions & { readonly tombstone?: "suppress" | undefined },
   ): Promise<Actor | null>;
+
+  /**
+   * Gets an {@link Actor} object or {@link Tombstone} for the given
+   * identifier.
+   * @param identifier The actor's identifier.
+   * @param options Options for getting the actor.
+   * @returns The actor object, a tombstone, or `null` if the actor is not
+   *          found.  This broad overload is used when the caller passes an
+   *          options value whose `tombstone` mode is not known statically.
+   * @throws {Error} If no actor dispatcher is available.
+   * @since 2.2.0
+   */
+  getActor(
+    identifier: string,
+    options: GetActorOptions,
+  ): Promise<Actor | Tombstone | null>;
 
   /**
    * Gets an object of the given class with the given values.

--- a/packages/fedify/src/federation/context.ts
+++ b/packages/fedify/src/federation/context.ts
@@ -8,6 +8,7 @@ import type {
   Multikey,
   Object,
   Recipient,
+  Tombstone,
   TraverseCollectionOptions,
 } from "@fedify/vocab";
 import type { DocumentLoader } from "@fedify/vocab-runtime";
@@ -438,6 +439,20 @@ export interface Context<TContextData> {
 }
 
 /**
+ * Options for {@link RequestContext.getActor}.
+ * @since 2.2.0
+ */
+export interface GetActorOptions {
+  /**
+   * Controls how tombstoned actors are returned.
+   *
+   * By default, tombstones are suppressed and returned as `null`.  Set this to
+   * `"passthrough"` to receive a {@link Tombstone} result instead.
+   */
+  readonly tombstone?: "suppress" | "passthrough";
+}
+
+/**
  * A context for a request.
  */
 export interface RequestContext<TContextData> extends Context<TContextData> {
@@ -469,6 +484,38 @@ export interface RequestContext<TContextData> extends Context<TContextData> {
    * @since 0.7.0
    */
   getActor(identifier: string): Promise<Actor | null>;
+
+  /**
+   * Gets an {@link Actor} object or {@link Tombstone} for the given
+   * identifier.
+   * @param identifier The actor's identifier.
+   * @param options Options for getting the actor.  Set
+   *                `options.tombstone` to `"passthrough"` to receive
+   *                tombstoned actors instead of `null`.
+   * @returns The actor object, a tombstone, or `null` if the actor is not
+   *          found.
+   * @throws {Error} If no actor dispatcher is available.
+   * @since 2.2.0
+   */
+  getActor(
+    identifier: string,
+    options: GetActorOptions & { readonly tombstone: "passthrough" },
+  ): Promise<Actor | Tombstone | null>;
+
+  /**
+   * Gets an {@link Actor} object for the given identifier.
+   * @param identifier The actor's identifier.
+   * @param options Options for getting the actor.
+   * @returns The actor object, or `null` if the actor is not found.
+   *          Tombstoned actors are suppressed unless `options.tombstone` is
+   *          `"passthrough"`.
+   * @throws {Error} If no actor dispatcher is available.
+   * @since 2.2.0
+   */
+  getActor(
+    identifier: string,
+    options?: GetActorOptions,
+  ): Promise<Actor | null>;
 
   /**
    * Gets an object of the given class with the given values.

--- a/packages/fedify/src/federation/federation.ts
+++ b/packages/fedify/src/federation/federation.ts
@@ -114,7 +114,9 @@ export interface Federatable<TContextData> {
    *             based on URI Template
    *             ([RFC 6570](https://tools.ietf.org/html/rfc6570)).  The path
    *             must have one variable: `{identifier}`.
-   * @param dispatcher An actor dispatcher callback to register.
+   * @param dispatcher An actor dispatcher callback to register.  It may return
+   *                   an actor, a {@link Tombstone}, or `null` if the actor is
+   *                   not found.
    * @returns An object with methods to set other actor dispatcher callbacks.
    * @throws {RouterError} Thrown if the path pattern is invalid.
    */

--- a/packages/fedify/src/federation/federation.ts
+++ b/packages/fedify/src/federation/federation.ts
@@ -115,8 +115,8 @@ export interface Federatable<TContextData> {
    *             ([RFC 6570](https://tools.ietf.org/html/rfc6570)).  The path
    *             must have one variable: `{identifier}`.
    * @param dispatcher An actor dispatcher callback to register.  It may return
-   *                   an actor, a {@link Tombstone}, or `null` if the actor is
-   *                   not found.
+   *                   an actor, a `Tombstone`, or `null` if the actor is not
+   *                   found.
    * @returns An object with methods to set other actor dispatcher callbacks.
    * @throws {RouterError} Thrown if the path pattern is invalid.
    */

--- a/packages/fedify/src/federation/handler.test.ts
+++ b/packages/fedify/src/federation/handler.test.ts
@@ -9,6 +9,7 @@ import {
   Note,
   type Object,
   Person,
+  Tombstone,
 } from "@fedify/vocab";
 import { FetchError } from "@fedify/vocab-runtime";
 import { assert, assertEquals } from "@std/assert";
@@ -68,6 +69,7 @@ const WRAPPER_QUOTE_CONTEXT_TERMS = {
 
 test("handleActor()", async () => {
   const federation = createFederation<void>({ kv: new MemoryKvStore() });
+  const deletedAt = Temporal.Instant.from("2024-01-15T00:00:00Z");
   let context = createRequestContext<void>({
     federation,
     data: undefined,
@@ -81,6 +83,13 @@ test("handleActor()", async () => {
     return new Person({
       id: ctx.getActorUri(identifier),
       name: "Someone",
+    });
+  };
+  const tombstoneDispatcher: ActorDispatcher<void> = (ctx, identifier) => {
+    if (identifier !== "gone") return null;
+    return new Tombstone({
+      id: ctx.getActorUri(identifier),
+      deleted: deletedAt,
     });
   };
   let onNotFoundCalled: Request | null = null;
@@ -291,6 +300,53 @@ test("handleActor()", async () => {
     id: "https://example.com/users/someone",
     type: "Person",
     name: "Someone",
+  });
+  assertEquals(onNotFoundCalled, null);
+  assertEquals(onUnauthorizedCalled, null);
+
+  onNotFoundCalled = null;
+  response = await handleActor(
+    context.request,
+    {
+      context,
+      identifier: "gone",
+      actorDispatcher: tombstoneDispatcher,
+      authorizePredicate: () => false,
+      onNotFound,
+      onUnauthorized,
+    },
+  );
+  assertEquals(response.status, 401);
+  assertEquals(onNotFoundCalled, null);
+  assertEquals(onUnauthorizedCalled, context.request);
+
+  onUnauthorizedCalled = null;
+  response = await handleActor(
+    context.request,
+    {
+      context,
+      identifier: "gone",
+      actorDispatcher: tombstoneDispatcher,
+      authorizePredicate: () => true,
+      onNotFound,
+      onUnauthorized,
+    },
+  );
+  assertEquals(response.status, 410);
+  assertEquals(
+    response.headers.get("Content-Type"),
+    "application/activity+json",
+  );
+  assertEquals(response.headers.get("Vary"), "Accept");
+  assertEquals(await response.json(), {
+    "@context": [
+      "https://www.w3.org/ns/activitystreams",
+      "https://w3id.org/security/data-integrity/v1",
+      "https://gotosocial.org/ns",
+    ],
+    id: "https://example.com/users/gone",
+    type: "Tombstone",
+    deleted: "2024-01-15T00:00:00Z",
   });
   assertEquals(onNotFoundCalled, null);
   assertEquals(onUnauthorizedCalled, null);

--- a/packages/fedify/src/federation/handler.ts
+++ b/packages/fedify/src/federation/handler.ts
@@ -10,6 +10,7 @@ import {
   Object,
   OrderedCollection,
   OrderedCollectionPage,
+  Tombstone,
 } from "@fedify/vocab";
 import type { DocumentLoader } from "@fedify/vocab-runtime";
 import { getLogger } from "@logtape/logtape";
@@ -103,6 +104,16 @@ export async function handleActor<TContextData>(
     if (!await authorizePredicate(context, identifier)) {
       return await onUnauthorized(request);
     }
+  }
+  if (actor instanceof Tombstone) {
+    const jsonLd = await actor.toJsonLd(context);
+    return new Response(JSON.stringify(jsonLd), {
+      status: 410,
+      headers: {
+        "Content-Type": "application/activity+json",
+        Vary: "Accept",
+      },
+    });
   }
   const jsonLd = await actor.toJsonLd(context);
   return new Response(JSON.stringify(jsonLd), {
@@ -560,7 +571,7 @@ async function handleInboxInternal<TContextData>(
     return await onNotFound(request);
   } else if (recipient != null) {
     const actor = await actorDispatcher(ctx, recipient);
-    if (actor == null) {
+    if (actor == null || actor instanceof Tombstone) {
       logger.error("Actor {recipient} not found.", { recipient });
       span.setStatus({
         code: SpanStatusCode.ERROR,

--- a/packages/fedify/src/federation/middleware.test.ts
+++ b/packages/fedify/src/federation/middleware.test.ts
@@ -39,7 +39,7 @@ import { FetchError, getDocumentLoader } from "@fedify/vocab-runtime";
 import { getAuthenticatedDocumentLoader } from "../utils/docloader.ts";
 
 const documentLoader = getDocumentLoader();
-import type { Context } from "./context.ts";
+import type { Context, GetActorOptions } from "./context.ts";
 import { MemoryKvStore } from "./kv.ts";
 import {
   ContextImpl,
@@ -952,6 +952,29 @@ test({
       void tombstoneActorTypeCheck;
       assertEquals(
         await tombstoneActorPromise,
+        new vocab.Tombstone({
+          id: new URL("https://example.com/users/gone"),
+          deleted: Temporal.Instant.from("2024-01-15T00:00:00Z"),
+        }),
+      );
+
+      const broadTombstoneOptions: GetActorOptions = {
+        tombstone: "passthrough",
+      };
+      const broadTombstoneActorPromise = ctx2.getActor(
+        "gone",
+        broadTombstoneOptions,
+      );
+      type BroadTombstoneActorType = Assert<
+        IsEqual<
+          Awaited<typeof broadTombstoneActorPromise>,
+          vocab.Actor | vocab.Tombstone | null
+        >
+      >;
+      const broadTombstoneActorTypeCheck: BroadTombstoneActorType = true;
+      void broadTombstoneActorTypeCheck;
+      assertEquals(
+        await broadTombstoneActorPromise,
         new vocab.Tombstone({
           id: new URL("https://example.com/users/gone"),
           deleted: Temporal.Instant.from("2024-01-15T00:00:00Z"),

--- a/packages/fedify/src/federation/middleware.test.ts
+++ b/packages/fedify/src/federation/middleware.test.ts
@@ -52,6 +52,10 @@ import type { MessageQueue } from "./mq.ts";
 import type { InboxMessage, Message, OutboxMessage } from "./queue.ts";
 import { RouterError } from "./router.ts";
 
+type IsEqual<A, B> = (<T>() => T extends A ? 1 : 2) extends
+  (<T>() => T extends B ? 1 : 2) ? true : false;
+type Assert<T extends true> = T;
+
 test("createFederation()", async (t) => {
   const kv = new MemoryKvStore();
 
@@ -927,7 +931,32 @@ test({
         await ctx2.getActor("john"),
         new vocab.Person({ preferredUsername: "john" }),
       );
-      assertEquals(await ctx2.getActor("gone"), null);
+      const defaultActorPromise = ctx2.getActor("gone");
+      type DefaultActorType = Assert<
+        IsEqual<Awaited<typeof defaultActorPromise>, vocab.Actor | null>
+      >;
+      const defaultActorTypeCheck: DefaultActorType = true;
+      void defaultActorTypeCheck;
+      assertEquals(await defaultActorPromise, null);
+
+      const tombstoneActorPromise = ctx2.getActor("gone", {
+        tombstone: "passthrough",
+      });
+      type TombstoneActorType = Assert<
+        IsEqual<
+          Awaited<typeof tombstoneActorPromise>,
+          vocab.Actor | vocab.Tombstone | null
+        >
+      >;
+      const tombstoneActorTypeCheck: TombstoneActorType = true;
+      void tombstoneActorTypeCheck;
+      assertEquals(
+        await tombstoneActorPromise,
+        new vocab.Tombstone({
+          id: new URL("https://example.com/users/gone"),
+          deleted: Temporal.Instant.from("2024-01-15T00:00:00Z"),
+        }),
+      );
 
       federation.setObjectDispatcher(
         vocab.Note,

--- a/packages/fedify/src/federation/middleware.test.ts
+++ b/packages/fedify/src/federation/middleware.test.ts
@@ -1331,7 +1331,7 @@ test("Federation.fetch()", async (t) => {
 
     assertEquals(dispatches, ["gone"]);
     assertEquals(response.status, 410);
-    assertEquals(await response.text(), "");
+    assertEquals(response.headers.get("Access-Control-Allow-Origin"), "*");
   });
 
   await t.step("POST to tombstoned inbox returns not found", async () => {

--- a/packages/fedify/src/federation/middleware.test.ts
+++ b/packages/fedify/src/federation/middleware.test.ts
@@ -911,8 +911,13 @@ test({
 
       federation.setActorDispatcher(
         "/users/{identifier}",
-        (_ctx, identifier) =>
-          new vocab.Person({ preferredUsername: identifier }),
+        (ctx, identifier) =>
+          identifier === "gone"
+            ? new vocab.Tombstone({
+              id: ctx.getActorUri(identifier),
+              deleted: Temporal.Instant.from("2024-01-15T00:00:00Z"),
+            })
+            : new vocab.Person({ preferredUsername: identifier }),
       );
       const ctx2 = federation.createContext(req, 789);
       assertEquals(ctx2.request, req);
@@ -922,6 +927,7 @@ test({
         await ctx2.getActor("john"),
         new vocab.Person({ preferredUsername: "john" }),
       );
+      assertEquals(await ctx2.getActor("gone"), null);
 
       federation.setObjectDispatcher(
         vocab.Note,
@@ -1047,6 +1053,12 @@ test("Federation.fetch()", async (t) => {
       "/users/{identifier}",
       (ctx, identifier) => {
         dispatches.push(identifier);
+        if (identifier === "gone") {
+          return new vocab.Tombstone({
+            id: ctx.getActorUri(identifier),
+            deleted: Temporal.Instant.from("2024-01-15T00:00:00Z"),
+          });
+        }
         return new vocab.Person({
           id: ctx.getActorUri(identifier),
           inbox: ctx.getInboxUri(identifier),
@@ -1226,6 +1238,63 @@ test("Federation.fetch()", async (t) => {
 
     assertEquals(dispatches, ["activity"]);
     assertEquals(response.status, 200);
+  });
+
+  await t.step("GET tombstoned actor returns 410 Gone", async () => {
+    const { federation, dispatches } = createTestContext();
+
+    const response = await federation.fetch(
+      new Request("https://example.com/users/gone", {
+        method: "GET",
+        headers: {
+          "Accept": "application/activity+json",
+        },
+      }),
+      { contextData: undefined },
+    );
+
+    assertEquals(dispatches, ["gone"]);
+    assertEquals(response.status, 410);
+    assertEquals(await response.json(), {
+      "@context": [
+        "https://www.w3.org/ns/activitystreams",
+        "https://w3id.org/security/data-integrity/v1",
+        "https://gotosocial.org/ns",
+      ],
+      id: "https://example.com/users/gone",
+      type: "Tombstone",
+      deleted: "2024-01-15T00:00:00Z",
+    });
+  });
+
+  await t.step("WebFinger for tombstoned actor returns 410 Gone", async () => {
+    const { federation, dispatches } = createTestContext();
+
+    const response = await federation.fetch(
+      new Request(
+        "https://example.com/.well-known/webfinger?resource=acct:gone@example.com",
+      ),
+      { contextData: undefined },
+    );
+
+    assertEquals(dispatches, ["gone"]);
+    assertEquals(response.status, 410);
+    assertEquals(await response.text(), "");
+  });
+
+  await t.step("POST to tombstoned inbox returns not found", async () => {
+    const { federation, inbox } = createTestContext();
+
+    const response = await federation.fetch(
+      new Request("https://example.com/users/gone/inbox", {
+        method: "POST",
+        headers: { "accept": "application/ld+json" },
+      }),
+      { contextData: undefined },
+    );
+
+    assertEquals(inbox, []);
+    assertEquals(response.status, 404);
   });
 
   await t.step("onNotAcceptable with GET", async () => {

--- a/packages/fedify/src/federation/middleware.ts
+++ b/packages/fedify/src/federation/middleware.ts
@@ -2670,12 +2670,19 @@ class RequestContextImpl<TContextData> extends ContextImpl<TContextData>
 
   getActor(
     identifier: string,
+  ): Promise<Actor | null>;
+  getActor(
+    identifier: string,
     options: GetActorOptions & { readonly tombstone: "passthrough" },
   ): Promise<Actor | Tombstone | null>;
   getActor(
     identifier: string,
-    options?: GetActorOptions,
+    options: GetActorOptions & { readonly tombstone?: "suppress" | undefined },
   ): Promise<Actor | null>;
+  getActor(
+    identifier: string,
+    options: GetActorOptions,
+  ): Promise<Actor | Tombstone | null>;
   async getActor(
     identifier: string,
     options?: GetActorOptions,

--- a/packages/fedify/src/federation/middleware.ts
+++ b/packages/fedify/src/federation/middleware.ts
@@ -71,6 +71,7 @@ import type {
   ActorKeyPair,
   Context,
   ForwardActivityOptions,
+  GetActorOptions,
   GetSignedKeyOptions,
   InboxContext,
   ParseUriResult,
@@ -2667,7 +2668,18 @@ class RequestContextImpl<TContextData> extends ContextImpl<TContextData>
     });
   }
 
-  async getActor(identifier: string): Promise<Actor | null> {
+  getActor(
+    identifier: string,
+    options: GetActorOptions & { readonly tombstone: "passthrough" },
+  ): Promise<Actor | Tombstone | null>;
+  getActor(
+    identifier: string,
+    options?: GetActorOptions,
+  ): Promise<Actor | null>;
+  async getActor(
+    identifier: string,
+    options?: GetActorOptions,
+  ): Promise<Actor | Tombstone | null> {
     if (
       this.federation.actorCallbacks == null ||
       this.federation.actorCallbacks.dispatcher == null
@@ -2693,7 +2705,10 @@ class RequestContextImpl<TContextData> extends ContextImpl<TContextData>
       }),
       identifier,
     );
-    return actor instanceof Tombstone ? null : actor;
+    if (actor instanceof Tombstone && options?.tombstone !== "passthrough") {
+      return null;
+    }
+    return actor;
   }
 
   async getObject<TObject extends Object>(

--- a/packages/fedify/src/federation/middleware.ts
+++ b/packages/fedify/src/federation/middleware.ts
@@ -13,6 +13,7 @@ import {
   getTypeId,
   lookupObject,
   Multikey,
+  Tombstone,
   traverseCollection,
 } from "@fedify/vocab";
 import type {
@@ -2685,13 +2686,14 @@ class RequestContextImpl<TContextData> extends ContextImpl<TContextData>
         },
       );
     }
-    return await this.federation.actorCallbacks.dispatcher(
+    const actor = await this.federation.actorCallbacks.dispatcher(
       new RequestContextImpl({
         ...this,
         invokedFromActorDispatcher: { identifier },
       }),
       identifier,
     );
+    return actor instanceof Tombstone ? null : actor;
   }
 
   async getObject<TObject extends Object>(

--- a/packages/fedify/src/federation/webfinger.test.ts
+++ b/packages/fedify/src/federation/webfinger.test.ts
@@ -1,6 +1,6 @@
 import { test } from "@fedify/fixture";
 import type { Actor } from "@fedify/vocab";
-import { Image, Link, Person } from "@fedify/vocab";
+import { Image, Link, Person, Tombstone } from "@fedify/vocab";
 import { assertEquals } from "@std/assert";
 import type {
   ActorAliasMapper,
@@ -27,10 +27,11 @@ test("handleWebFinger()", async (t) => {
         return new URL(`${url.origin}/users/${identifier}`);
       },
       async getActor(handle): Promise<Actor | null> {
-        return await actorDispatcher(
+        const actor = await actorDispatcher(
           context,
           handle,
         );
+        return actor instanceof Tombstone ? null : actor;
       },
       parseUri(uri) {
         if (uri == null) return null;
@@ -48,6 +49,12 @@ test("handleWebFinger()", async (t) => {
   }
 
   const actorDispatcher: ActorDispatcher<void> = (ctx, identifier) => {
+    if (identifier === "gone") {
+      return new Tombstone({
+        id: ctx.getActorUri(identifier),
+        deleted: Temporal.Instant.from("2024-01-15T00:00:00Z"),
+      });
+    }
     if (identifier !== "someone" && identifier !== "someone2") return null;
     const actorUri = ctx.getActorUri(identifier);
     return new Person({
@@ -217,6 +224,34 @@ test("handleWebFinger()", async (t) => {
     });
     assertEquals(response.status, 200);
     assertEquals(await response.json(), expected2);
+  });
+
+  await t.step("gone: resource=acct:...", async () => {
+    const u = new URL(url);
+    u.searchParams.set("resource", "acct:gone@example.com");
+    const context = createContext(u);
+    const request = context.request;
+    const response = await handleWebFinger(request, {
+      context,
+      actorDispatcher,
+      onNotFound,
+    });
+    assertEquals(response.status, 410);
+    assertEquals(onNotFoundCalled, null);
+  });
+
+  await t.step("gone: resource=https:...", async () => {
+    const u = new URL(url);
+    u.searchParams.set("resource", "https://example.com/users/gone");
+    const context = createContext(u);
+    const request = context.request;
+    const response = await handleWebFinger(request, {
+      context,
+      actorDispatcher,
+      onNotFound,
+    });
+    assertEquals(response.status, 410);
+    assertEquals(onNotFoundCalled, null);
   });
 
   await t.step("not found: resource=acct:...", async () => {

--- a/packages/fedify/src/federation/webfinger.test.ts
+++ b/packages/fedify/src/federation/webfinger.test.ts
@@ -237,6 +237,7 @@ test("handleWebFinger()", async (t) => {
       onNotFound,
     });
     assertEquals(response.status, 410);
+    assertEquals(response.headers.get("Access-Control-Allow-Origin"), "*");
     assertEquals(onNotFoundCalled, null);
   });
 
@@ -251,6 +252,7 @@ test("handleWebFinger()", async (t) => {
       onNotFound,
     });
     assertEquals(response.status, 410);
+    assertEquals(response.headers.get("Access-Control-Allow-Origin"), "*");
     assertEquals(onNotFoundCalled, null);
   });
 

--- a/packages/fedify/src/federation/webfinger.ts
+++ b/packages/fedify/src/federation/webfinger.ts
@@ -201,7 +201,12 @@ async function handleWebFingerInternal<TContextData>(
     return await onNotFound(request);
   }
   if (actor instanceof Tombstone) {
-    return new Response(null, { status: 410 });
+    return new Response(null, {
+      status: 410,
+      headers: {
+        "Access-Control-Allow-Origin": "*",
+      },
+    });
   }
   const links: Link[] = [
     {
@@ -243,9 +248,7 @@ async function handleWebFingerInternal<TContextData>(
   }
 
   const aliases: string[] = [];
-  const preferredUsername = actor instanceof Tombstone
-    ? null
-    : actor.preferredUsername;
+  const preferredUsername = actor.preferredUsername;
   if (resourceUrl.protocol != "acct:" && preferredUsername != null) {
     aliases.push(`acct:${preferredUsername}@${host ?? context.url.host}`);
     if (host != null && host !== context.url.host) {

--- a/packages/fedify/src/federation/webfinger.ts
+++ b/packages/fedify/src/federation/webfinger.ts
@@ -1,4 +1,4 @@
-import { Link as LinkObject } from "@fedify/vocab";
+import { Link as LinkObject, Tombstone } from "@fedify/vocab";
 import type { Link, ResourceDescriptor } from "@fedify/webfinger";
 import { getLogger } from "@logtape/logtape";
 import type { Span, Tracer } from "@opentelemetry/api";
@@ -200,6 +200,9 @@ async function handleWebFingerInternal<TContextData>(
     logger.error("Actor {identifier} not found.", { identifier });
     return await onNotFound(request);
   }
+  if (actor instanceof Tombstone) {
+    return new Response(null, { status: 410 });
+  }
   const links: Link[] = [
     {
       rel: "self",
@@ -240,10 +243,13 @@ async function handleWebFingerInternal<TContextData>(
   }
 
   const aliases: string[] = [];
-  if (resourceUrl.protocol != "acct:" && actor.preferredUsername != null) {
-    aliases.push(`acct:${actor.preferredUsername}@${host ?? context.url.host}`);
+  const preferredUsername = actor instanceof Tombstone
+    ? null
+    : actor.preferredUsername;
+  if (resourceUrl.protocol != "acct:" && preferredUsername != null) {
+    aliases.push(`acct:${preferredUsername}@${host ?? context.url.host}`);
     if (host != null && host !== context.url.host) {
-      aliases.push(`acct:${actor.preferredUsername}@${context.url.host}`);
+      aliases.push(`acct:${preferredUsername}@${context.url.host}`);
     }
   }
   if (resourceUrl.href !== context.getActorUri(identifier).href) {


### PR DESCRIPTION
## What may look surprising

The most surprising part of this change is that `RequestContext.getActor()` still returns `null` for tombstoned actors by default, even though actor dispatchers can now return `Tombstone`. That is intentional. I did not want to widen the effective behavior of existing internal and application call sites all at once, because a lot of code reasonably treats `getActor()` as “give me a live actor or nothing.” The new `{ tombstone: "passthrough" }` overload makes tombstones available where callers explicitly want that distinction, without silently changing the meaning of existing code.

Another point that may look odd at first is that the external HTTP surface and the internal helper API now differ on purpose. Actor endpoints and WebFinger now surface deleted actors as `410 Gone`, which is the ActivityPub-facing behavior this issue asked for. Internal lookups still default to the older “null means not usable as a live actor” behavior unless the caller opts into tombstone passthrough.

## What changed

This PR allows actor dispatchers to return `Tombstone` in *packages/fedify/src/federation/callback.ts* and updates actor handling in *packages/fedify/src/federation/handler.ts* so actor endpoints return `410 Gone` with the serialized tombstone body.

It also updates WebFinger handling in *packages/fedify/src/federation/webfinger.ts* so deleted actors return `410 Gone` there as well, instead of falling through as if the account had never been handled.

`RequestContext.getActor()` is now overloaded in *packages/fedify/src/federation/context.ts* and implemented in *packages/fedify/src/federation/middleware.ts* so callers can opt into `Tombstone` results with `{ tombstone: "passthrough" }`, while the default overload still returns `Promise<Actor | null>`.

I also updated the actor-dispatcher wrapper in *packages/fedify/src/federation/builder.ts* so tombstones are allowed through without being subjected to actor-only shape checks such as inbox, outbox, followers, or public key expectations. The `id` consistency check still applies, because that remains important for both live actors and tombstones.

The documentation updates are in *docs/manual/actor.md*, *docs/manual/context.md*, *docs/manual/webfinger.md*, *docs/tutorial/basics.md*, and *CHANGES.md*.

## Points I was careful about

I kept the authorization order on actor endpoints intact. The tempting change would have been to return `410 Gone` immediately when the dispatcher returns a tombstone, but that would have changed the visibility of protected actor endpoints and could have leaked the existence of deleted actors behind `authorize()` checks. The current behavior still evaluates authorization first, then returns `410` only for authorized requests.

I also kept inbox recipient resolution conservative. In *packages/fedify/src/federation/handler.ts*, a tombstoned recipient is still treated as not found for inbox handling. Letting a deleted actor pass through there would have been a subtle regression, because inbox delivery code expects a live actor with live routing properties.

The easiest mistake here would have been to make `RequestContext.getActor()` always return `Actor | Tombstone | null` and then fix whatever broke. That would have pushed a new semantic burden onto a lot of existing code for very little benefit. I avoided that by making tombstone passthrough opt-in and verifying the overload behavior in tests.

Another easy mistake would have been to remember the actor endpoint change and forget WebFinger, or to return a JRD for a deleted actor. I added explicit WebFinger `410` coverage so that behavior stays aligned.

## Testing

I implemented this TDD-style, starting with failing coverage in *packages/fedify/src/federation/handler.test.ts*, *packages/fedify/src/federation/webfinger.test.ts*, and *packages/fedify/src/federation/middleware.test.ts* before changing the runtime code.

The new tests cover actor endpoint `410` responses, WebFinger `410` responses, the default `RequestContext.getActor()` suppression behavior, and the new `{ tombstone: "passthrough" }` overload including its compile-time return type.

I also ran `hongdown -w` on the updated Markdown files, built the docs with `pnpm build` inside *docs/*, and ran `mise test` before each commit and again after the follow-up overload change.