### PR TITLE
Document SiliconBeest in why guide

### DIFF
--- a/.hongdown.toml
+++ b/.hongdown.toml
@@ -76,6 +76,7 @@ proper_nouns = [
   "RabbitMQ",
   "Redis",
   "Scoop",
+  "SiliconBeest",
   "SolidStart",
   "SvelteKit",
   "Typo Blue",

--- a/docs/why.md
+++ b/docs/why.md
@@ -320,6 +320,23 @@ writing, allowing users to focus purely on text without images or attachments:
 
 [Typo Blue]: https://typo.blue/
 
+### SiliconBeest: Serverless federation on Cloudflare Workers
+
+[SiliconBeest] is a serverless fediverse platform built on Cloudflare Workers,
+demonstrating how Fedify can power ActivityPub federation on edge-native
+infrastructure:
+
+ -  Built a Mastodon API-compatible social networking server on Cloudflare
+    Workers
+ -  Uses Fedify together with *@fedify/cfworkers* to handle federation,
+    message delivery, signatures, WebFinger, and related protocol concerns
+ -  Combines Fedify with platform-native services like KV and Queues to support
+    a serverless deployment model
+ -  Shows how Fedify can be adapted beyond conventional server environments for
+    ActivityPub applications
+
+[SiliconBeest]: https://github.com/SJang1/siliconbeest
+
 
 Conclusion
 ----------


### PR DESCRIPTION
## Summary
- Add SiliconBeest to *docs/why.md* as a success story
- Whitelist the name in *.hongdown.toml* to preserve casing

## Why
SiliconBeest is a public Fedify deployment on Cloudflare Workers via `@fedify/cfworkers`, which makes it a useful addition to the success stories because we did not have a serverless example listed yet.